### PR TITLE
Remove objects early

### DIFF
--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -259,8 +259,6 @@ if (file.exists(bonds_inputs_file)) {
     }
   }
 
-  rm(ald_scen_cb)
-  rm(ald_raw_cb)
   rm(port_raw_all_cb)
   rm(port_raw_cb)
   rm(port_cb)


### PR DESCRIPTION
fixes #54

Remove large objects as soon as possible to reduce peak memory usage. (I still peak at 23+GB during web tool script 2 with this PR, but it seems to be slightly better/faster).