### PR TITLE
Revert "install vim in Docker"

### DIFF
--- a/transitionmonitor_docker/Dockerfile
+++ b/transitionmonitor_docker/Dockerfile
@@ -7,7 +7,6 @@
 FROM rocker/r-ver:4.1.2
 
 # install system dependencies
-# nano only for utility, not needed for PACTA
 ARG SYS_DEPS="\
     git \
     libcurl4-openssl-dev \


### PR DESCRIPTION
Reverts RMI-PACTA/workflow.transition.monitor#69

having `vim` in the dokcer image isn't inherently bad, but the preferred paradigm is to use volume mounts to access/override files in the container, and edit those on the host system.