### PR TITLE
Revert "add HEAD hash of each repo to a `head_hashes` env var in the Docker"

### DIFF
--- a/transitionmonitor_docker/Dockerfile
+++ b/transitionmonitor_docker/Dockerfile
@@ -100,7 +100,5 @@ RUN chmod -R a+rwX /bound \
 # set the build_version environment variable
 ARG image_tag
 ENV build_version=$image_tag
-ARG head_hashes
-ENV head_hashes=$head_hashes
 
 RUN exit 0

--- a/transitionmonitor_docker/build_with_tag.sh
+++ b/transitionmonitor_docker/build_with_tag.sh
@@ -138,18 +138,6 @@ done
 green "repos successfully cloned into temp directory\n"
 
 
-# grab hash of the HEAD for each repo
-head_hashes=()
-for repo in $repos
-do
-    head_hash=$(git -C "$repo" rev-parse --verify --short HEAD || exit 2)
-    head_hashes+=("'$repo: $head_hash'")
-    green "$(basename $repo) short hash of head is $head_hash"
-done
-head_hashes=$( printf '%s\n' "${head_hashes[@]}" )
-green "HEAD hash successfully captures for each repo\n"
-
-
 # set git tag in each repo and log
 for repo in $repos
 do
@@ -174,7 +162,6 @@ green "Building rmi_pacta Docker image...\n"
 
 docker build \
     --build-arg image_tag=$tag \
-    --build-arg head_hashes=$head_hashes \
     --platform $platform \
     --tag rmi_pacta:$tag \
     --tag rmi_pacta:latest \


### PR DESCRIPTION
This seems to cause build errors when running ./build-with-tag.sh

Reverts RMI-PACTA/workflow.transition.monitor#81
reopens #67 