### PR TITLE
add {benchmarkme} dependency for pacta.interactive.report

### DIFF
--- a/transitionmonitor_docker/Dockerfile
+++ b/transitionmonitor_docker/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update \
 
 # install R package dependencies
 ARG PKG_DEPS="\
+    benchmarkme \
     bookdown \
     cli \
     config \


### PR DESCRIPTION
relates to https://github.com/RMI-PACTA/pacta.interactive.report/pull/90