### PR TITLE
Add `textcomp` to TeX dependencies

### DIFF
--- a/transitionmonitor_docker/Dockerfile
+++ b/transitionmonitor_docker/Dockerfile
@@ -62,6 +62,7 @@ ARG TEX_DEPS="\
     l3packages \
     mdframed \
     needspace \
+    textcomp \
     tools \
     xcolor \
     zref \


### PR DESCRIPTION
Relates to https://github.com/RMI-PACTA/pacta.executive.summary/issues/200