### PR TITLE
fix bug introduced by #142

### DIFF
--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -81,6 +81,10 @@ portfolio <- process_raw_portfolio(
   isin_to_fund_table = isin_to_fund_table
 )
 
+# FIXME: this is necessary because pacta.portfolio.analysis::add_revenue_split()
+#  was removed in #142, but later we realized that it had a sort of hidden
+#  behavior where if there is no revenue data it maps the security_mapped_sector
+#  column of the portfolio data to financial_sector, which is necessary later
 portfolio <-
   portfolio %>%
   mutate(


### PR DESCRIPTION
#142 introduced a bug because `pacta.portfolio.analysis::add_revenue_split()` has a somewhat hidden behavior of mapping the `security_mapped_sector` column of the portfolio data to `financial_sector`, which is then needed later on.

This is not a pretty solution (probably we should just rename the column from the start in data.prep eventually), but it gets the job done exactly where it used to.

As reference, we need to replicate the behavior here: https://github.com/RMI-PACTA/pacta.portfolio.analysis/blob/b7f837d0e19774fc8e81570ab7c0bc395788a595/R/add_revenue_split.R#L50-L56