### PR TITLE
use {pak} for package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,9 @@ ARG TEX_DEPS="\
     "
 RUN tlmgr --repository $CTAN_REPO install $TEX_DEPS
 
+# copy in scripts from this repo
+COPY workflow.transition.monitor /bound
+
 # install R package dependencies
 RUN Rscript -e "\
     install.packages(c('pak', 'renv')); \
@@ -79,7 +82,6 @@ COPY pacta.executive.summary /pacta.executive.summary
 COPY pacta.interactive.report /pacta.interactive.report
 COPY pacta.portfolio.analysis /pacta.portfolio.analysis
 COPY pacta.portfolio.import /pacta.portfolio.import
-COPY workflow.transition.monitor /bound
 
 # install PACTA R packages
 RUN Rscript -e "\


### PR DESCRIPTION
closes #150 

in draft mode because I haven't fully tested yet, but this "should" make the install faster (and uses {renv} to determine dependencies of the scripts in this repo, rather than maintaining a separate list manually here in the Docker file)