### PR TITLE
add Docker build test GitHub Action

### DIFF
--- a/.github/workflows/test-Docker-build.yml
+++ b/.github/workflows/test-Docker-build.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [Docker-build-test-GH-action]
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The goal of this is to have a GH Action that runs on every PR to clone all the relevant repos and try building the Docker image, just to make sure we can at least build the Docker image with the changes in the current PR. It's a start towards having some minimal testing happening in this repo, though obviously test everything we ideally would be testing.


@jdhoffa to put this to the test, it has to be on [main], so... can we merge this and test it out... obviously we can easily remove it if it causes trouble