### PR TITLE
push image to registry

### DIFF
--- a/.github/workflows/test-Docker-build.yml
+++ b/.github/workflows/test-Docker-build.yml
@@ -73,6 +73,8 @@ jobs:
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           # Use Docker `latest` tag convention
           [ "$VERSION" == "main" ] && VERSION=latest
+          # if from a PR, use the PR number
+          [ "$VERSION" == "merge" ] && VERSION=$(echo "PR${{ github.event.pull_request.number }}")
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION


### PR DESCRIPTION
This PR modifies the Docker image build GH Action to push the built image to the GitHub container repository, where it can be accessed for testing locally where one may have access to the necessary pacta-data.

---

image created by this GH Action for this PR can be loaded locally with
```
docker pull ghcr.io/rmi-pacta/workflow.transition.monitor:pr159
```

and/or can be tested using an external pacta-data dataset that is accessible locally by mounting it into the Docker container, e.g...
```
portfolio_name="TestPortfolio"
userFolder=~/Desktop/TestPortfolio
dataFolder=~/github/rmi-pacta/pacta-data

docker run -ti --rm --network none \
  --mount type=bind,source=${userFolder},target=/bound/working_dir \
  --mount type=bind,readonly,source=${dataFolder},target=/pacta-data \
  ghcr.io/rmi-pacta/workflow.transition.monitor:pr159 \
  /bound/bin/run-r-scripts "$portfolio_name"
```