### PR TITLE
add a comment to PR with image install prompt

### DIFF
--- a/.github/workflows/test-Docker-build.yml
+++ b/.github/workflows/test-Docker-build.yml
@@ -82,14 +82,15 @@ jobs:
           docker push $IMAGE_ID:$VERSION
           echo "BUILD_NAME_TAG=$IMAGE_ID:$VERSION" >> $GITHUB_OUTPUT
 
-#      - name: Find Comment
-#        if: ${{ github.event_name == 'pull_request' }}
-#        uses: peter-evans/find-comment@v2
-#        id: fc
-#        with:
-#          issue-number: ${{ github.event.pull_request.number }}
-#          comment-author: 'github-actions[bot]'
-#          body-includes: Docker image from this PR created
+      - name: Find Comment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          token: ${{ secrets.PAT_ADD_ISSUES_TO_PROJECT }}
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Docker image from this PR created
 
       - name: Create or update comment
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
When a Docker image is auto-created from a PR, this will add a comment to the PR Conversation with a command specifying how to load the PR's Docker image locally.