### PR TITLE
pacta.portfolio.analysis -> pacta.portfolio.allocate

### DIFF
--- a/.github/workflows/test-Docker-build.yml
+++ b/.github/workflows/test-Docker-build.yml
@@ -29,12 +29,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: pacta.portfolio.import
 
-      - name: Checkout pacta.portfolio.analysis
+      - name: Checkout pacta.portfolio.allocate
         uses: actions/checkout@v3
         with:
-          repository: RMI-PACTA/pacta.portfolio.analysis
+          repository: RMI-PACTA/pacta.portfolio.allocate
           token: ${{ secrets.PAT_ADD_ISSUES_TO_PROJECT }}
-          path: pacta.portfolio.analysis
+          path: pacta.portfolio.allocate
 
       - name: Checkout pacta.portfolio.audit
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN Rscript -e "pak::pkg_install(c('renv', 'yaml'))"
 # copy in DESCRIPTION files from local PACTA package clones
 COPY pacta.executive.summary/DESCRIPTION /pacta.executive.summary/DESCRIPTION
 COPY pacta.interactive.report/DESCRIPTION /pacta.interactive.report/DESCRIPTION
-COPY pacta.portfolio.analysis/DESCRIPTION /pacta.portfolio.analysis/DESCRIPTION
+COPY pacta.portfolio.allocate/DESCRIPTION /pacta.portfolio.allocate/DESCRIPTION
 COPY pacta.portfolio.audit/DESCRIPTION /pacta.portfolio.audit/DESCRIPTION
 COPY pacta.portfolio.import/DESCRIPTION /pacta.portfolio.import/DESCRIPTION
 COPY pacta.portfolio.utils/DESCRIPTION /pacta.portfolio.utils/DESCRIPTION
@@ -102,7 +102,7 @@ RUN Rscript -e "\
     c( \
       'pacta.executive.summary', \
       'pacta.interactive.report', \
-      'pacta.portfolio.analysis', \
+      'pacta.portfolio.allocate', \
       'pacta.portfolio.audit', \
       'pacta.portfolio.import', \
       'pacta.portfolio.utils' \
@@ -120,7 +120,7 @@ RUN Rscript -e "\
 # copy in local PACTA package clones
 COPY pacta.executive.summary /pacta.executive.summary
 COPY pacta.interactive.report /pacta.interactive.report
-COPY pacta.portfolio.analysis /pacta.portfolio.analysis
+COPY pacta.portfolio.allocate /pacta.portfolio.allocate
 COPY pacta.portfolio.audit /pacta.portfolio.audit
 COPY pacta.portfolio.import /pacta.portfolio.import
 COPY pacta.portfolio.utils /pacta.portfolio.utils
@@ -131,7 +131,7 @@ RUN Rscript -e "\
     c( \
       'pacta.executive.summary', \
       'pacta.interactive.report', \
-      'pacta.portfolio.analysis', \
+      'pacta.portfolio.allocate', \
       'pacta.portfolio.audit', \
       'pacta.portfolio.import', \
       'pacta.portfolio.utils' \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The tree of the docker container looks like this:
 /bound  # contents of workflow.transition.monitor
 /pacta.executive.summary
 /pacta.interactive.report
-/pacta.portfolio.analysis
+/pacta.portfolio.allocate
 /pacta.portfolio.import
 /pacta-data
 ```

--- a/build/build_with_tag.sh
+++ b/build/build_with_tag.sh
@@ -37,7 +37,7 @@ fi
 if [ -z "${repos}" ]; then
     repos="\
         pacta.portfolio.import \
-        pacta.portfolio.analysis \
+        pacta.portfolio.allocate \
         pacta.portfolio.audit \
         pacta.portfolio.utils \
         pacta.interactive.report \

--- a/parameter_files/WebParameters_local.yml
+++ b/parameter_files/WebParameters_local.yml
@@ -1,7 +1,7 @@
 default:
     paths:
        # Use form "../this_repo/" (not "./" or "/path/to/this_repo")
-        project_location_ext: ../pacta.portfolio.analysis/
+        project_location_ext: ../pacta.portfolio.allocate/
         data_location_ext: ../pacta-data/2021Q4/
         template_location: ../pacta.interactive.report/
         user_data_location: ../user_results/

--- a/tests/run-like-constructiva-flags.sh
+++ b/tests/run-like-constructiva-flags.sh
@@ -7,8 +7,8 @@ usage() {
   echo "[-t <docker image tag>] (default latest)" 1>&2
   echo "[-u <userId>] (default 4)" 1>&2
   echo "[-m <docker image>] (default rmi_pacta)" 1>&2
-  # a for pacta.portfolio.analysis
-  echo "[-a <path to local pacta.portfolio.analysis repo>] (default docker internal)" 1>&2
+  # a for pacta.portfolio.allocate
+  echo "[-a <path to local pacta.portfolio.allocate repo>] (default docker internal)" 1>&2
   # d for pacta-data
   echo "[-d <path to local pacta-data repo>] (default docker internal)" 1>&2
   # c for pacta.interactive.report

--- a/web_tool_script_1.R
+++ b/web_tool_script_1.R
@@ -81,7 +81,7 @@ portfolio <- process_raw_portfolio(
   isin_to_fund_table = isin_to_fund_table
 )
 
-# FIXME: this is necessary because pacta.portfolio.analysis::add_revenue_split()
+# FIXME: this is necessary because pacta.portfolio.allocate::add_revenue_split()
 #  was removed in #142, but later we realized that it had a sort of hidden
 #  behavior where if there is no revenue data it maps the security_mapped_sector
 #  column of the portfolio data to financial_sector, which is necessary later

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -1,6 +1,6 @@
 suppressPackageStartupMessages({
   library(pacta.portfolio.utils)
-  library(pacta.portfolio.analysis)
+  library(pacta.portfolio.allocate)
   library(cli)
   library(dplyr)
 })


### PR DESCRIPTION
We have forked [pacta.portfolio.analysis](https://github.com/RMI-PACTA/pacta.portfolio.analysis) into a new public repository called [pacta.portfolio.allocate](https://github.com/RMI-PACTA/pacta.portfolio.allocate).

This PR makes use of the newly created package. 
