### PR TITLE
Remove deprecated `tdm_scenarios()`

### DIFF
--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -154,7 +154,7 @@ if (inherits(port_raw_all_eq, "data.frame") && nrow(port_raw_all_eq) > 0) {
 
       saveRDS(equity_tdm, file.path(pf_file_results_path, "Equity_tdm.rds"))
 
-      port_all_eq <- filter(port_all_eq, !scenario %in% tdm_scenarios())
+      port_all_eq <- filter(port_all_eq, !scenario %in% tdm_vars$scenarios)
     }
 
     saveRDS(port_all_eq, file.path(pf_file_results_path, "Equity_results_portfolio.rds"))
@@ -281,7 +281,7 @@ if (inherits(port_raw_all_cb, "data.frame") && nrow(port_raw_all_cb) > 0) {
 
       saveRDS(bonds_tdm, file.path(pf_file_results_path, "Bonds_tdm.rds"))
 
-      port_all_cb <- filter(port_all_cb, !scenario %in% tdm_scenarios())
+      port_all_cb <- filter(port_all_cb, !scenario %in% tdm_vars$scenarios)
     }
 
     saveRDS(port_all_cb, file.path(pf_file_results_path, "Bonds_results_portfolio.rds"))


### PR DESCRIPTION
Sorry it looks like I missed a stray `tdm_scenarios()` call.

Relates to https://github.com/RMI-PACTA/pacta.portfolio.allocate/issues/3 and
https://github.com/RMI-PACTA/workflow.transition.monitor/pull/179