### PR TITLE
Check that dataset exists before trying to add columns

### DIFF
--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -58,7 +58,7 @@ readRDS_or_return_alt_data <- function(filepath, alt_return = NULL) {
 }
 
 add_inv_and_port_names_if_needed <- function(data) {
-  if (!inherits(data, data.frame)) {
+  if (!inherits(data, "data.frame")) {
     return(data)
   }
 


### PR DESCRIPTION
There is a (non-negligible) chance that the TDM datasets don't exist, so when they are read in they return NULL. 

If this is the case, `mutate()` will fail since it cannot mutate an object of class `NULL`

Relates to https://github.com/RMI-PACTA/workflow.transition.monitor/pull/182