### PR TITLE
Filter TDM inputs for "Global" `scenario_geography` and `equity_market`

### DIFF
--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -116,6 +116,9 @@ if (inherits(port_raw_all_eq, "data.frame") && nrow(port_raw_all_eq) > 0) {
     saveRDS(company_all_eq, file.path(pf_file_results_path, "Equity_results_company.rds"))
   }
   if (data_check(port_all_eq)) {
+    port_all_eq_tdm <- port_all_eq %>%
+      filter(scenario_geography == "Global", equity_market == "GlobalMarket")
+  
     tdm_vars <- list(
       t0 = start_year,
       delta_t1 = 5,
@@ -132,7 +135,7 @@ if (inherits(port_raw_all_eq, "data.frame") && nrow(port_raw_all_eq) > 0) {
 
     if (
       tdm_conditions_met(
-        port_all_eq,
+        port_all_eq_tdm,
         t0 = tdm_vars$t0,
         delta_t1 = tdm_vars$delta_t1,
         delta_t2 = tdm_vars$delta_t2,
@@ -144,7 +147,7 @@ if (inherits(port_raw_all_eq, "data.frame") && nrow(port_raw_all_eq) > 0) {
 
       equity_tdm <-
         calculate_tdm(
-          port_all_eq,
+          port_all_eq_tdm,
           t0 = tdm_vars$t0,
           delta_t1 = tdm_vars$delta_t1,
           delta_t2 = tdm_vars$delta_t2,
@@ -243,6 +246,9 @@ if (inherits(port_raw_all_cb, "data.frame") && nrow(port_raw_all_cb) > 0) {
     saveRDS(company_all_cb, file.path(pf_file_results_path, "Bonds_results_company.rds"))
   }
   if (data_check(port_all_cb)) {
+    port_all_cb_tdm <- port_all_cb %>%
+      filter(scenario_geography == "Global", equity_market == "GlobalMarket")
+    
     tdm_vars <- list(
       t0 = start_year,
       delta_t1 = 5,
@@ -259,7 +265,7 @@ if (inherits(port_raw_all_cb, "data.frame") && nrow(port_raw_all_cb) > 0) {
 
     if (
       tdm_conditions_met(
-        port_all_cb,
+        port_all_cb_tdm,
         t0 = tdm_vars$t0,
         delta_t1 = tdm_vars$delta_t1,
         delta_t2 = tdm_vars$delta_t2,
@@ -271,7 +277,7 @@ if (inherits(port_raw_all_cb, "data.frame") && nrow(port_raw_all_cb) > 0) {
 
       bonds_tdm <-
         calculate_tdm(
-          port_all_cb,
+          port_all_cb_tdm,
           t0 = tdm_vars$t0,
           delta_t1 = tdm_vars$delta_t1,
           delta_t2 = tdm_vars$delta_t2,


### PR DESCRIPTION
I believe, initially, we only received IPR data for these regions. It seems we have since updated to more specific region definitions, however, the downstream plotting code is not yet sensitive to differing input regions so we must feed it only one. 