### PR TITLE
build Docker image every weekday at 00:00 UTC

### DIFF
--- a/.github/workflows/nightly-docker-build.yml
+++ b/.github/workflows/nightly-docker-build.yml
@@ -78,7 +78,7 @@ jobs:
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          # Use Docker `latest` tag convention
+          # Use Docker `nightly` tag convention
           VERSION=nightly
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION


### PR DESCRIPTION
Adds a separate GH Action to push a nightly (weekdays at 00:00 UTC) Docker build to ghcr.io (of all relevant repos at main).

Note to self: when #184 merges, this action should be similarly updated

closes #186 