### PR TITLE
Add `2022Q4` Project Parameters

### DIFF
--- a/parameter_files/ProjectParameters_Indices2022Q4.yml
+++ b/parameter_files/ProjectParameters_Indices2022Q4.yml
@@ -1,0 +1,74 @@
+default:
+
+    paths:
+        data_location_ext: ../pacta-data/2022Q4/
+
+    parameters:
+        timestamp: 2022Q4
+        dataprep_timestamp: 2022Q4_transitionmonitor
+        start_year: 2022
+        horizon_year: 5
+        select_scenario: WEO2022_NZE_2050
+        scenario_other: GECO2022_1.5C
+        portfolio_allocation_method: portfolio_weight
+        scenario_geography: Global
+
+    methodology:
+        has_map: TRUE
+        has_revenue: FALSE
+        has_credit: FALSE
+        inc_emissionfactors: TRUE
+
+    sectors:
+        tech_roadmap_sectors:
+            - Power
+            - Automotive
+            - Oil&Gas
+            - Coal
+        pacta_sectors_not_analysed:
+            - Steel
+            - Aviation
+            - Cement
+        green_techs:
+            - RenewablesCap
+            - HydroCap
+            - NuclearCap
+            - Hybrid
+            - Electric
+            - FuelCell
+            - Electric Arc Furnace
+        alignment_techs:
+            - RenewablesCap
+            - CoalCap
+            - Coal
+            - Oil
+            - Gas
+            - Electric
+            - ICE
+
+    asset_types:
+        - Equity
+        - Bonds
+        - Others
+        - Funds
+
+    scenario_sources_list:
+        - GECO2022
+        - IPR2021
+        - ISF2021
+        - WEO2022
+
+    scenario_geography_list:
+        - Global
+        - GlobalAggregate
+        - NonOECD
+        - OECD
+
+    equity_market_list:
+        - GlobalMarket
+        - DevelopedMarket
+        - EmergingMarket
+
+    grouping_variables:
+        - investor_name
+        - portfolio_name


### PR DESCRIPTION
For these project parameters, I used the `2021Q4` indices parameters as a baseline, but changed:
* The list of scenarios to that which is in the `workflow.data.preparation/config.yml` for `2022Q4`
* All references from 2021 to 2022
* The `select_scenario` and `scenario_other` to their analogous values in the updated scenarios 