### PR TITLE
Bump `ProjectParameters_GENERAL.yml` to `2022Q4`

### DIFF
--- a/parameter_files/ProjectParameters_GENERAL.yml
+++ b/parameter_files/ProjectParameters_GENERAL.yml
@@ -1,7 +1,7 @@
 default:
 
     paths:
-        data_location_ext: ../pacta-data/2021Q4/
+        data_location_ext: ../pacta-data/2022Q4/
 
     reporting:
         project_report_name: general
@@ -9,12 +9,12 @@ default:
         currency_exchange_value: 1
 
     parameters:
-        timestamp: 2021Q4
-        dataprep_timestamp: 2021Q4
-        start_year: 2021
+        timestamp: 2022Q4
+        dataprep_timestamp: 2022Q4
+        start_year: 2022
         horizon_year: 5
-        select_scenario: WEO2021_NZE_2050
-        scenario_other: GECO2021_1.5C-Unif
+        select_scenario: WEO2022_NZE_2050
+        scenario_other: GECO2022_1.5C
         portfolio_allocation_method: portfolio_weight
         scenario_geography: Global
 
@@ -58,11 +58,10 @@ default:
         - Funds
 
     scenario_sources_list:
-        - ETP2020
-        - WEO2021
-        - GECO2021
-        - ISF2021
+        - GECO2022
         - IPR2021
+        - ISF2021
+        - WEO2022
 
     scenario_geography_list:
         - Global


### PR DESCRIPTION
This pretty awkward implementation...

I need to bump the `GENERAL.yml` file to point to the `2022Q4` information. This means that there is a commit SHA of `workflow.transition.monitor` where GENERAL points to `2021Q4` and corresponds to the `rmi_pacta:2021q4_1.0.0` image, 

and then there will also be a SHA that points to `2022Q4` and corresponds to the `rmi_pacta:2022q4_1.0.0`. 

Does this mean that we can only have the `GENERAL` initiative use EITHER `2021Q4` or `2022Q4`, but can't have users switch between them? 