### PR TITLE
add minimal Docker image labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ ARG PLATFORM="linux/amd64"
 ARG R_VERS="4.2.3"
 FROM --platform=$PLATFORM rocker/r-ver:$R_VERS
 
+LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/workflow.transition.monitor
+LABEL org.opencontainers.image.description="Docker image to drive the Transition Monitor backend"
+LABEL org.opencontainers.image.licenses=MIT
+
 ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-03-31+MbiAEzHt"
 RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site"
 


### PR DESCRIPTION
The Rocker base image has a bunch of labels assigned in it, which our image inherits and they are then displayed in the repositories metadata (e.g. [here](https://github.com/RMI-PACTA/workflow.transition.monitor/pkgs/container/workflow.transition.monitor/110330691?tag=nightly)). This sets the minimal set of labels suggested by GitHub [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images).

We may want to consider also re-setting (possibly by setting them to `""`?) the other labels set by Rocker? e.g.
```json
"labels": {
    "org.opencontainers.image.source": "https://github.com/rocker-org/rocker-versioned2",
    "org.opencontainers.image.title": "rocker/r-ver",
    "org.opencontainers.image.revision": "ef593dcd7b334e02e79188a9e17dcf6149c178b9",
    "org.opencontainers.image.version": "R-4.2.3",
    "org.opencontainers.image.description": "Reproducible builds to fixed version of R",
    "org.opencontainers.image.vendor": "Rocker Project",
    "org.opencontainers.image.licenses": "GPL-2.0-or-later",
    "org.opencontainers.image.base.name": "docker.io/library/ubuntu:jammy",
    "org.opencontainers.image.ref.name": "ubuntu",
    "org.opencontainers.image.authors": "Carl Boettiger <cboettig@ropensci.org>"
  }
```
