### PR TITLE
remove data path reference

### DIFF
--- a/parameter_files/ProjectParameters_GENERAL.yml
+++ b/parameter_files/ProjectParameters_GENERAL.yml
@@ -1,8 +1,5 @@
 default:
 
-    paths:
-        data_location_ext: ../pacta-data/2022Q4/
-
     reporting:
         project_report_name: general
         display_currency: USD


### PR DESCRIPTION
Removing data path in GENERAL Template file, since this caused portfolios to _always_ use that data, even if a different holdings date is used in the portfolio parameters file.