### PR TITLE
remove `project_name` parameter

### DIFF
--- a/parameter_files/WebParameters_docker.yml
+++ b/parameter_files/WebParameters_docker.yml
@@ -5,6 +5,5 @@ default:
         template_location: /templates.transition.monitor/
         user_data_location: /user_results/
     parameters:
-        project_name: working_dir
         new_data: FALSE
 

--- a/parameter_files/WebParameters_local.yml
+++ b/parameter_files/WebParameters_local.yml
@@ -6,6 +6,5 @@ default:
         template_location: ../templates.transition.monitor/
         user_data_location: ../user_results/
     parameters:
-        project_name: working_dir
         new_data: FALSE
 

--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -221,7 +221,6 @@ create_interactive_report(
   survey_dir = survey_dir,
   real_estate_dir = real_estate_dir,
   language_select = language_select,
-  project_name = project_name,
   investor_name = investor_name,
   portfolio_name = portfolio_name,
   peer_group = peer_group,


### PR DESCRIPTION
In the `workflow.transition.monitor` use case, the `project_name` parameter is set in the `parameter_files/WebParameters_docker.yml` and/or `parameter_files/WebParameters_local.yml` files, but it is never used except for being passed as an argument to `create_interactive_report()` which also never uses the argument. Additionally, it is set by default to `"working_dir"` in both cases, which suggests that this is a long leftover option that is not being used as expected. `create_interactive_report()` sets a default value for its `project_name` argument (which is also set to `"working_dir"` by default), so removing that argument from the call in `web_tool_script_3.R` should not have any negative effect. I would suggest that once this PR is merged, that the `project_name` argument also be removed from `create_interactive_report()` in `pacta.portfolio.report`.

@AlexAxthelm @jacobvjk @Antoine-Lalechere I have a minor concern that `project_name` may be used/expected in some other workflows, and removing it here may cause some confusion as `workflow.transition.monitor` is usually considered the standard model for how PACTA *should* be run, but removing it here should not immediately break any other workflows as far as I can tell. Do you have nay concerns about this?