### PR TITLE
install most recent version of {pak}

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ ARG TEMPLATES_DIR="/templates.transition.monitor"
 COPY $TEMPLATES_SRC $TEMPLATES_DIR
 
 # install packages for dependency resolution and installation
-RUN Rscript -e "install.packages('pak')"
+RUN Rscript -e "install.packages('pak', repos = 'https://r-lib.github.io/p/pak/stable/', lib = Sys.getenv('R_LIB_FOR_PAK'))"
 RUN Rscript -e "pak::pkg_install(c('renv', 'yaml'))"
 
 # copy in scripts from this repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ ARG TEMPLATES_DIR="/templates.transition.monitor"
 COPY $TEMPLATES_SRC $TEMPLATES_DIR
 
 # install packages for dependency resolution and installation
-RUN Rscript -e "install.packages('pak', repos = 'https://r-lib.github.io/p/pak/stable/', lib = Sys.getenv('R_LIB_FOR_PAK'))"
+RUN Rscript -e "install.packages('pak', repos = 'https://r-lib.github.io/p/pak/stable/')"
 RUN Rscript -e "pak::pkg_install(c('renv', 'yaml'))"
 
 # copy in scripts from this repo


### PR DESCRIPTION
While freezing the R package dependencies at a certain date makes sense, using the most up to date version of {pak} to install those dependencies is ideal.