### PR TITLE
remove `new_data` parameter that is defunct

### DIFF
--- a/parameter_files/WebParameters_docker.yml
+++ b/parameter_files/WebParameters_docker.yml
@@ -6,5 +6,4 @@ default:
         user_data_location: /user_results/
     parameters:
         project_name: working_dir
-        new_data: FALSE
 

--- a/parameter_files/WebParameters_local.yml
+++ b/parameter_files/WebParameters_local.yml
@@ -7,5 +7,4 @@ default:
         user_data_location: ../user_results/
     parameters:
         project_name: working_dir
-        new_data: FALSE
 


### PR DESCRIPTION
The `new_data` parameter was used in previous versions of `PACTA_analysis` to trigger an on-the-fly processing of some data files (e.g. currencies) rather than relying on preprocessed files, but that ability has been completely removed was the current/modern data.prep process was created.
https://github.com/RMI-PACTA/PACTA_analysis/blob/9f760b8319791db07dc07317ea844965980b181f/web_tool_script_1.R#L37-L44