### PR TITLE
do not load R pkg {config}

### DIFF
--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -6,7 +6,6 @@ suppressPackageStartupMessages({
   library(dplyr)
   library(readr)
   library(jsonlite)
-  library(config)
   library(fs)
 })
 


### PR DESCRIPTION
The R pkg {config} should never be loaded with `library(config)` because its functions will override common, important base R functions. Not sure how we never noticed this.