### PR TITLE
Update R packages snapshot date to 2023-10-30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 # https://rocker-project.org/images/versioned/r-ver.html
 #
 # sets CRAN repo to use Posit Package Manager to freeze R package versions to
-# those available on 2023-08-31
+# those available on 2023-10-30
 # https://packagemanager.posit.co/client/#/repos/2/overview
-# https://packagemanager.posit.co/cran/__linux__/jammy/2023-08-31
+# https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30
 #
 # sets CTAN repo to freeze TeX package dependencies to those available on
 # 2021-12-31
@@ -26,7 +26,7 @@ LABEL org.opencontainers.image.base.name=""
 LABEL org.opencontainers.image.ref.name=""
 LABEL org.opencontainers.image.authors=""
 
-ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-08-31"
+ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30"
 RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site"
 
 # set apt-get to noninteractive mode


### PR DESCRIPTION
closes #225

Update R packages snapshot date to 2023-10-30 so that it includes dbplyr v2.4.0