### PR TITLE
R studio auto changed files

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,0 @@
-^.*\.Rproj$
-^\.Rproj\.user$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .Rhistory
 .RData
 .Ruserdata
+.Rbuildignore
 .DS_Store

--- a/workflow.transition.monitor.Rproj
+++ b/workflow.transition.monitor.Rproj
@@ -15,3 +15,7 @@ LaTeX: pdfLaTeX
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes
 LineEndingConversion: Posix
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
As with https://github.com/RMI-PACTA/workflow.data.preparation/pull/93 and https://github.com/RMI-PACTA/workflow.data.preparation/pull/117, having a `DESCRIPTION` file in the repo causes RStudio to add/modify `.Rbuildignore` and `workflow.transition.monitor.Rproj`. This PR appeases RStudio so we don't fight against it