### PR TITLE
fix(docker): fix path to pacta-data

### DIFF
--- a/build/build_private_docker.sh
+++ b/build/build_private_docker.sh
@@ -16,6 +16,7 @@ az acr login --name transitionmonitordockerregistry
 
 pacta_data_share_url="https://pactadatadev.file.core.windows.net/workflow-data-preparation-outputs"
 pacta_data_share_path="2023Q4_20240218T231047Z"
+holdings_date="2023Q4"
 
 templates_remote="git@github.com:RMI-PACTA/templates.transition.monitor.git"
 templates_branch="main"
@@ -34,7 +35,7 @@ local_tag="$docker_image":"$tag"
 git clone -b "$templates_branch" "$templates_remote" --depth 1 "$dir_temp/templates.transition.monitor"|| exit 2
 
 # exclude sqlite files from download
-az storage copy -s "$pacta_data_share_url"/"$pacta_data_share_path"  -d "$dir_temp/pacta-data" --recursive --exclude-pattern "*.sqlite"
+az storage copy -s "$pacta_data_share_url"/"$pacta_data_share_path/*"  -d "$dir_temp/pacta-data/$holdings_date" --recursive --exclude-pattern "*.sqlite"
 
 docker build -f Dockerfile.private -t "$local_tag" "$dir_temp"
 


### PR DESCRIPTION
Fixes path to pacta-data in private docker image. Previously, build would COPY data to timestamped directory
(`/pacta-data/2023Q4_20240218T231047Z`). Now copies to path expected by PACTA (`/pacta-data/2023Q4`).

No associated issue.
Relates to #247