### PR TITLE
add badges to README

### DIFF
--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -1,3 +1,5 @@
+name: Docker build
+
 on:
   pull_request:
   push:

--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -1,4 +1,4 @@
-name: Docker build
+name: Docker build & test
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!-- badges: start -->
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![.github/workflows/build-Docker-image-triggers.yml](https://github.com/RMI-PACTA/workflow.transition.monitor/actions/workflows/build-Docker-image-triggers.yml/badge.svg)](https://github.com/RMI-PACTA/workflow.transition.monitor/actions/workflows/build-Docker-image-triggers.yml)
+<!-- badges: end -->
+
 # Description
 
 The Dockerfile in this repository creates an image containing a freshly cloned copy of workflow.transition.monitor and templates.transition.monitor. It also installs the relevant public PACTA R packages from their respective GitHub repos. It also adds the relevant quarter PACTA data directory under `/pacta-data`.


### PR DESCRIPTION
closes #274

also added name "Docker build & test" to the `build-Docker-image-triggers.yml` so we get a better looking badge:
[![.github/workflows/build-Docker-image-triggers.yml](https://github.com/RMI-PACTA/workflow.transition.monitor/actions/workflows/build-Docker-image-triggers.yml/badge.svg)](https://github.com/RMI-PACTA/workflow.transition.monitor/actions/workflows/build-Docker-image-triggers.yml)
