### PR TITLE
Use new comment action with history

### DIFF
--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -27,34 +27,6 @@ jobs:
           github.sha 
         }}
 
-  add_comment:
-    if: ${{ github.event_name == 'pull_request' }}
-    needs: build_docker_image
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Find Comment
-        # https://github.com/peter-evans/find-comment
-        uses: peter-evans/find-comment@v3
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Docker image from this PR
-
-      - name: Create or update comment
-        # https://github.com/peter-evans/create-or-update-comment
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            Docker image from this PR (${{ github.event.pull_request.head.sha }}) created
-            ```
-            docker pull ${{ needs.build_docker_image.outputs.full-image-name }}
-            ```
-          edit-mode: replace
-
   build_private_docker_image:
     name: "Build private docker image"
     strategy:
@@ -70,4 +42,11 @@ jobs:
     secrets: inherit
     with:
       image-name: ${{ matrix.image-name }}
+
+  add-comment:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: RMI-PACTA/actions/.github/workflows/add-comment-history.yml@feat/57-comment-history
+    needs: [build_docker_image, build_private_docker_image]
+    with:
+      header: "Docker build status"
 

--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -45,7 +45,7 @@ jobs:
 
   add-comment:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: RMI-PACTA/actions/.github/workflows/add-comment-history.yml@cbb8f138b56fabd0215e73b42800ca15793d8ff9
+    uses: RMI-PACTA/actions/.github/workflows/add-comment-history.yml@main
     needs: [build_docker_image, build_private_docker_image]
     with:
       header: "Docker build status"

--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -45,7 +45,7 @@ jobs:
 
   add-comment:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: RMI-PACTA/actions/.github/workflows/add-comment-history.yml@848ef2b1867a2481204db16c038434ce2333b92e
+    uses: RMI-PACTA/actions/.github/workflows/add-comment-history.yml@cbb8f138b56fabd0215e73b42800ca15793d8ff9
     needs: [build_docker_image, build_private_docker_image]
     with:
       header: "Docker build status"

--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -45,7 +45,7 @@ jobs:
 
   add-comment:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: RMI-PACTA/actions/.github/workflows/add-comment-history.yml@feat/57-comment-history
+    uses: RMI-PACTA/actions/.github/workflows/add-comment-history.yml@main
     needs: [build_docker_image, build_private_docker_image]
     with:
       header: "Docker build status"

--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -45,7 +45,7 @@ jobs:
 
   add-comment:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: RMI-PACTA/actions/.github/workflows/add-comment-history.yml@main
+    uses: RMI-PACTA/actions/.github/workflows/add-comment-history.yml@848ef2b1867a2481204db16c038434ce2333b92e
     needs: [build_docker_image, build_private_docker_image]
     with:
       header: "Docker build status"

--- a/.github/workflows/build-and-push-Docker-image.yml
+++ b/.github/workflows/build-and-push-Docker-image.yml
@@ -49,3 +49,19 @@ jobs:
           docker tag ${{ inputs.image-name }} $full_image_name
           docker push $full_image_name
           echo "full-image-name=$full_image_name" >> $GITHUB_OUTPUT
+
+      - name: Export Outputs
+        id: export-outputs
+        run: |
+          mkdir -p /tmp/comment-json
+          json_filename=$( \
+            echo "comment-json-merge-${{ inputs.image-name }}-${{ inputs.image-tag }}.json" | \
+            tr '/' '-' \
+            )
+          echo "json-filename=$json_filename" >> "$GITHUB_ENV"
+          json_file="/tmp/comment-json/$json_filename"
+          jq -n '{
+            "commit_time": "${{ github.event.pull_request.updated_at }}",
+            "git_sha": "${{ github.event.pull_request.head.sha }}",
+            "image": "${{ steps.push-image.outputs.full-image-name }}"
+          }' >> $json_file

--- a/.github/workflows/build-and-push-Docker-image.yml
+++ b/.github/workflows/build-and-push-Docker-image.yml
@@ -65,3 +65,11 @@ jobs:
             "git_sha": "${{ github.event.pull_request.head.sha }}",
             "image": "${{ steps.push-image.outputs.full-image-name }}"
           }' >> $json_file
+
+      - name: Upload comment JSON
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.json-filename }}
+          path: /tmp/comment-json/*
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/build-and-push-Docker-image.yml
+++ b/.github/workflows/build-and-push-Docker-image.yml
@@ -55,8 +55,8 @@ jobs:
         run: |
           mkdir -p /tmp/comment-json
           json_filename=$( \
-            echo "comment-json-merge-${{ inputs.image-name }}-${{ inputs.image-tag }}.json" | \
-            tr '/' '-' \
+            echo "comment-json-merge-${{ inputs.image-name }}-build-push.json" | \
+            tr '/.' '-' \
             )
           echo "json-filename=$json_filename" >> "$GITHUB_ENV"
           json_file="/tmp/comment-json/$json_filename"

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -348,9 +348,9 @@ jobs:
           echo "json-filename=$json_filename" >> "$GITHUB_ENV"
           json_file="/tmp/comment-json/$json_filename"
           jq -n '{
-            "commit_time": "${{ github.event.pull_request.updated_at }}"
+            "commit_time": "${{ github.event.pull_request.updated_at }}",
             "git_sha": "${{ github.event.pull_request.head.sha }}",
-            "image": "${{ steps.export-outputs.outputs.full-image-name }}"
+            "image": "${{ steps.export-outputs.outputs.full-image-name }}",
             "language": "${{ matrix.language }}",
             "peer_group": "${ matrix.peer_group }",
             "report": "[Report]($REPORT_URL)"

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -267,7 +267,9 @@ jobs:
           config_file="build/config/${{ inputs.image-name }}.json"
           cp $config_file $TEST_DIR
           PROJECT_CODE="$(jq -r '.project_code' $config_file)"
+          echo "PROJECT_CODE=$PROJECT_CODE" >> "$GITHUB_ENV"
           PACTA_DATA_QUARTER="$(jq -r '.pacta_data_quarter' $config_file)"
+          echo "PACTA_DATA_QUARTER=$PACTA_DATA_QUARTER" >> "$GITHUB_ENV"
 
           params_file="$TEST_DIR/working_dir/10_Parameter_File/${{ inputs.image-name }}_PortfolioParameters.yml"
           mkdir -p "$(dirname $params_file)"
@@ -354,6 +356,8 @@ jobs:
           jq -n '{
             "commit_time": "${{ github.event.pull_request.updated_at }}",
             "git_sha": "${{ github.event.pull_request.head.sha }}",
+            "project_code": "${{ env.PROJECT_CODE }}",
+            "holdings_date": "${{ env.PACTA_DATA_QUARTER }}",
             "language": "${{ matrix.language }}",
             "peer_group": "${{ matrix.peer_group }}",
             "report": "[Report](${{ env.report-url }})",

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -340,6 +340,9 @@ jobs:
           echo "report-url=$REPORT_URL"
           echo "report-url=$REPORT_URL" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare comment artifact
+        id: prepare-artifact
+        run: |
           mkdir -p /tmp/comment-json
           json_filename=$( \
             echo "comment-json-merge-${{ inputs.image-name }}-${{ inputs.registry }}-${{ matrix.language }}-${{ matrix.peer_group }}.json" | \
@@ -350,10 +353,10 @@ jobs:
           jq -n '{
             "commit_time": "${{ github.event.pull_request.updated_at }}",
             "git_sha": "${{ github.event.pull_request.head.sha }}",
-            "image": "${{ steps.export-outputs.outputs.full-image-name }}",
+            "image": "${{ jobs.docker-build.outputs.full-image-name }}",
             "language": "${{ matrix.language }}",
-            "peer_group": "${ matrix.peer_group }",
-            "report": "[Report]($REPORT_URL)"
+            "peer_group": "${{ matrix.peer_group }}",
+            "report": "[Report](${{ steps.export-outputs.outputs.report_url }})"
           }' >> $json_file
 
       - name: Upload comment JSON

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -354,10 +354,10 @@ jobs:
           jq -n '{
             "commit_time": "${{ github.event.pull_request.updated_at }}",
             "git_sha": "${{ github.event.pull_request.head.sha }}",
-            "image": "${{ needs.docker-build.outputs.full-image-name }}",
             "language": "${{ matrix.language }}",
             "peer_group": "${{ matrix.peer_group }}",
-            "report": "[Report](${{ env.report-url }})"
+            "report": "[Report](${{ env.report-url }})",
+            "image": "${{ needs.docker-build.outputs.full-image-name }}"
           }' >> $json_file
 
       - name: Upload comment JSON

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -340,33 +340,26 @@ jobs:
           echo "report-url=$REPORT_URL"
           echo "report-url=$REPORT_URL" >> "$GITHUB_OUTPUT"
 
-          artifact_id="report-outputs-${{ inputs.image-name }}-${{ matrix.language }}-${{ matrix.peer_group }}"
-          echo "artifact-id=$artifact_id"
-          echo "artifact-id=$artifact_id" >> "$GITHUB_ENV"
+          mkdir -p /tmp/comment-json
+          json_filename=$( \
+            echo "comment-json-merge-${{ inputs.image-name }}-${{ inputs.registry }}-${{ matrix.language }}-${{ matrix.peer_group }}.json" | \
+            tr '/' '-' \
+            )
+          echo "json-filename=$json_filename" >> "$GITHUB_ENV"
+          json_file="/tmp/comment-json/$json_filename"
+          jq -n '{
+            "commit_time": ${{ github.event.pull_request.updated_at }}
+            "git_sha": "${{ github.event.pull_request.head.sha }}",
+            "image": "${{ steps.export-outputs.outputs.full-image-name }}"
+            "language": "${{ matrix.language }}",
+            "peer_group": "${ matrix.peer_group }",
+            "report": "[Report]($REPORT_URL)"
+          }' >> $json_file
 
-          artifact_filename="outputs/$artifact_id.txt"
-          mkdir -p "$(dirname $artifact_filename)"
-          echo "artifact-filename=$artifact_filename"
-          echo "artifact-filename=$artifact_filename" >> "$GITHUB_ENV"
-          echo "$REPORT_URL" >> "$artifact_filename"
-
-      - uses: actions/upload-artifact@v4
+      - name: Upload comment JSON
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.artifact-id }}
-          path: ${{ env.artifact-filename }}
-
-  collect:
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Load outputs
-        uses: actions/download-artifact@v4
-        with:
-          pattern: "report-outputs-*"
-          merge-multiple: true
-          path: outputs/
-
-      - run: |
-          ls outputs/
-          cat outputs/*.txt
+          name: ${{ env.json-filename }}
+          path: /tmp/comment-json/*
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -348,7 +348,7 @@ jobs:
           echo "json-filename=$json_filename" >> "$GITHUB_ENV"
           json_file="/tmp/comment-json/$json_filename"
           jq -n '{
-            "commit_time": ${{ github.event.pull_request.updated_at }}
+            "commit_time": "${{ github.event.pull_request.updated_at }}"
             "git_sha": "${{ github.event.pull_request.head.sha }}",
             "image": "${{ steps.export-outputs.outputs.full-image-name }}"
             "language": "${{ matrix.language }}",

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -357,7 +357,7 @@ jobs:
             "language": "${{ matrix.language }}",
             "peer_group": "${{ matrix.peer_group }}",
             "report": "[Report](${{ env.report-url }})",
-            "image": "${{ needs.docker-build.outputs.full-image-name }}"
+            "image": "`${{ needs.docker-build.outputs.full-image-name }}`"
           }' >> $json_file
 
       - name: Upload comment JSON

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -339,6 +339,7 @@ jobs:
           REPORT_URL="https://${{ inputs.reports-account }}.blob.core.windows.net/${{ inputs.reports-container }}/${{ env.TEST_DIR }}/working_dir/50_Outputs/${{ inputs.image-name }}/report/index.html"
           echo "report-url=$REPORT_URL"
           echo "report-url=$REPORT_URL" >> "$GITHUB_OUTPUT"
+          echo "report-url=$REPORT_URL" >> "$GITHUB_ENV"
 
       - name: Prepare comment artifact
         id: prepare-artifact
@@ -353,10 +354,10 @@ jobs:
           jq -n '{
             "commit_time": "${{ github.event.pull_request.updated_at }}",
             "git_sha": "${{ github.event.pull_request.head.sha }}",
-            "image": "${{ jobs.docker-build.outputs.full-image-name }}",
+            "image": "${{ needs.docker-build.outputs.full-image-name }}",
             "language": "${{ matrix.language }}",
             "peer_group": "${{ matrix.peer_group }}",
-            "report": "[Report](${{ steps.export-outputs.outputs.report_url }})"
+            "report": "[Report](${{ env.report-url }})"
           }' >> $json_file
 
       - name: Upload comment JSON


### PR DESCRIPTION
- [x] Depends on https://github.com/RMI-PACTA/actions/pull/62
- [x] Depends on https://github.com/RMI-PACTA/actions/pull/63

Adds code to export information about build and testing status to use comment action from RMI-PACTA/actions repo