### PR TITLE
facilitate easier testing by aligning parameter names

### DIFF
--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -204,6 +204,9 @@ class(configs$project_config) <- c(class(configs$project_config), "list")
 template_dir_name <- paste(tolower(project_report_name), tolower(language_select), "template", sep = "_")
 template_dir <- file.path(template_path, template_dir_name)
 
+select_scenario_other <- scenario_other
+twodi_sectors <- sector_list
+
 create_interactive_report(
   template_dir = template_dir,
   output_dir = output_dir,
@@ -215,10 +218,10 @@ create_interactive_report(
   peer_group = peer_group,
   start_year = start_year,
   select_scenario = select_scenario,
-  select_scenario_other = scenario_other,
+  select_scenario_other = select_scenario_other,
   portfolio_allocation_method = portfolio_allocation_method,
   scenario_geography = scenario_geography,
-  twodi_sectors = sector_list,
+  twodi_sectors = twodi_sectors,
   green_techs = green_techs,
   tech_roadmap_sectors = tech_roadmap_sectors,
   pacta_sectors_not_analysed = pacta_sectors_not_analysed,


### PR DESCRIPTION
this is a bit of a hack, but it makes manual/step-through testing a bit easier by aligning the object names in the global environment with the parameter names in `create_interactive_report()`