### PR TITLE
build(docker): Update references to use dev version of GENERAL report

### DIFF
--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -35,7 +35,6 @@ jobs:
       # build images in parallel
       matrix:
         image-name:
-          - rmi_pacta_2023q4_pa2024ch
           - rmi_pacta_2022q4_general
           - rmi_pacta_2023q4_general
     uses: ./.github/workflows/build-push-private.yml

--- a/build/config/rmi_pacta_2022q4_general.json
+++ b/build/config/rmi_pacta_2022q4_general.json
@@ -3,7 +3,7 @@
   "index_share_path": "2022Q4_20240304T205931Z",
   "pacta_data_quarter": "2022Q4",
   "project_code": "GENERAL",
-  "templates_ref": "",
+  "templates_ref": "feature/text-updates",
   "test_matrix": {
     "language": [
       "EN"

--- a/build/config/rmi_pacta_2023q4_general.json
+++ b/build/config/rmi_pacta_2023q4_general.json
@@ -3,7 +3,7 @@
   "index_share_path": "2023Q4_20240301T145404Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "GENERAL",
-  "templates_ref": "",
+  "templates_ref": "feature/text-updates",
   "test_matrix": {
     "language": [
       "EN"


### PR DESCRIPTION
**Not a real PR**

Updating the refs for `templates.transition.monitor`, so that we can run the build and test pipeline from this repo to see outputs from https://github.com/RMI-PACTA/templates.transition.monitor/pull/2