### PR TITLE
don't merge: test if `WEO2022_NZE` works better than `WEO2022_NZE_2050`

### DIFF
--- a/parameter_files/ProjectParameters_GENERAL_2022Q4.yml
+++ b/parameter_files/ProjectParameters_GENERAL_2022Q4.yml
@@ -11,7 +11,7 @@ default:
     parameters:
         start_year: 2022
         horizon_year: 5
-        select_scenario: WEO2022_NZE
+        select_scenario: WEO2022_NZE_2050
         scenario_other: GECO2022_1.5C
         portfolio_allocation_method: portfolio_weight
         scenario_geography: Global

--- a/parameter_files/ProjectParameters_GENERAL_2022Q4.yml
+++ b/parameter_files/ProjectParameters_GENERAL_2022Q4.yml
@@ -11,7 +11,7 @@ default:
     parameters:
         start_year: 2022
         horizon_year: 5
-        select_scenario: WEO2022_NZE_2050
+        select_scenario: WEO2022_NZE
         scenario_other: GECO2022_1.5C
         portfolio_allocation_method: portfolio_weight
         scenario_geography: Global

--- a/parameter_files/ProjectParameters_GENERAL_2023Q4.yml
+++ b/parameter_files/ProjectParameters_GENERAL_2023Q4.yml
@@ -11,8 +11,8 @@ default:
     parameters:
         start_year: 2023
         horizon_year: 5
-        select_scenario: WEO2023_NZE_2050
-        scenario_other: WEO2023_NZE_2050
+        select_scenario: WEO2023_NZE
+        scenario_other: WEO2023_NZE
         portfolio_allocation_method: portfolio_weight
         scenario_geography: Global
 

--- a/parameter_files/ProjectParameters_PA2024CH.yml
+++ b/parameter_files/ProjectParameters_PA2024CH.yml
@@ -11,8 +11,8 @@ default:
     parameters:
         start_year: 2023
         horizon_year: 5
-        select_scenario: WEO2023_NZE_2050
-        scenario_other: WEO2023_NZE_2050
+        select_scenario: WEO2023_NZE
+        scenario_other: WEO2023_NZE
         portfolio_allocation_method: portfolio_weight
         scenario_geography: Global
 


### PR DESCRIPTION
Since https://github.com/RMI-PACTA/pacta.scenario.preparation/pull/140 (Feb 29), `WEO2022_NZE` is now `WEO2022_NZE_2050`, but the currently selected input datasets were created before that, and therefore use/have `WEO2022_NZE`. This is just a test to see if aligning the config files with the scenario naming in the input datasets will improve the reports' plotting problems.

https://github.com/RMI-PACTA/workflow.transition.monitor/blob/6bc7fcdd051116f48f9d8c3374c6efdbc02860f7/build/config/rmi_pacta_2022q4_general.json#L2

https://github.com/RMI-PACTA/workflow.transition.monitor/blob/6bc7fcdd051116f48f9d8c3374c6efdbc02860f7/build/config/rmi_pacta_2023q4_general.json#L2

https://github.com/RMI-PACTA/workflow.transition.monitor/blob/6bc7fcdd051116f48f9d8c3374c6efdbc02860f7/build/config/rmi_pacta_2023q4_pa2024ch.json#L2

⚠️ NOTE: I'm not sure why the 2023Q4 dataset built on `20240301` did not pickup the change in `pacta.scenario.preparation`, but I verified that it did not...

``` r
equity_abcd_scenario_WEO2023 <- readRDS("~/data/workflow-data-preparation-outputs/2023Q4_20240301T105304Z/equity_abcd_scenario_WEO2023.rds")

unique(equity_abcd_scenario_WEO2023$scenario)
#> [1] "APS"   "NZE"   "STEPS"
```

⚠️ NOTE: Even weirder still, the 2022Q4 dataset built on `20240218` *does* have `WEO2022_NZE_2050`...
``` r
equity_abcd_scenario_WEO2022 <- readRDS("~/data/workflow-data-preparation-outputs/2022Q4_20240218T194337Z/equity_abcd_scenario_WEO2022.rds")

unique(equity_abcd_scenario_WEO2022$scenario)
#> [1] "APS"      "NZE_2050" "STEPS"
```

⚠️ This is just a test. We should probably re-run data.prep and update the build configs to use the latest data.prep outputs eventually, after which the proper specification in the parameter files here should be `WEO2022_NZE_2050`, as it is currently on `main`.

ℹ️ FYI @AlexAxthelm and @jdhoffa