### PR TITLE
remove `project_location_ext`

### DIFF
--- a/parameter_files/WebParameters_docker.yml
+++ b/parameter_files/WebParameters_docker.yml
@@ -1,6 +1,5 @@
 default:
     paths:
-        project_location_ext: /bound/
         data_location_ext: /pacta-data/2021Q4/
         template_location: /templates.transition.monitor/
         user_data_location: /user_results/

--- a/parameter_files/WebParameters_local.yml
+++ b/parameter_files/WebParameters_local.yml
@@ -1,7 +1,6 @@
 default:
     paths:
        # Use form "../this_repo/" (not "./" or "/path/to/this_repo")
-        project_location_ext: ../pacta.portfolio.allocate/
         data_location_ext: ../pacta-data/2021Q4/
         template_location: ../templates.transition.monitor/
         user_data_location: ../user_results/


### PR DESCRIPTION
- [x] depends on https://github.com/RMI-PACTA/pacta.portfolio.utils/pull/26

`project_location_ext` is an old parameter used in `PACTA_analysis` that is no longer in use in any of our active repos (except here, and `pacta.portfolio.utils::set_web_parameters()` which is being removed in https://github.com/RMI-PACTA/pacta.portfolio.utils/pull/26)

https://github.com/search?q=org%3ARMI-PACTA+project_location_ext+NOT+is%3Aarchived&type=code

ℹ️ As I understand it, the working directory is used implicitly instead of what this parameter used to set explicitly.