### PR TITLE
build(docker): #296 change pin date for R packages

### DIFF
--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -47,7 +47,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    timeout-minutes: 15
+    timeout-minutes: 45
     outputs:
       full-image-name: ${{ steps.export-outputs.outputs.full-image-name }}
       test-matrix: ${{ steps.prepare.outputs.test-matrix }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 # https://rocker-project.org/images/versioned/r-ver.html
 #
 # sets CRAN repo to use Posit Package Manager to freeze R package versions to
-# those available on 2023-10-30
+# those available on 2024-03-05
 # https://packagemanager.posit.co/client/#/repos/2/overview
-# https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30
+# https://packagemanager.posit.co/cran/__linux__/jammy/2024-03-05
 #
 # sets CTAN repo to freeze TeX package dependencies to those available on
 # 2021-12-31

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ LABEL org.opencontainers.image.base.name=""
 LABEL org.opencontainers.image.ref.name=""
 LABEL org.opencontainers.image.authors=""
 
-ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-03-04"
+ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2024-03-04"
 RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site"
 
 # set apt-get to noninteractive mode

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ LABEL org.opencontainers.image.base.name=""
 LABEL org.opencontainers.image.ref.name=""
 LABEL org.opencontainers.image.authors=""
 
-ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2024-03-04"
+ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2024-03-05"
 RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site"
 
 # set apt-get to noninteractive mode

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ LABEL org.opencontainers.image.base.name=""
 LABEL org.opencontainers.image.ref.name=""
 LABEL org.opencontainers.image.authors=""
 
-ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30"
+ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-03-04"
 RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site"
 
 # set apt-get to noninteractive mode


### PR DESCRIPTION
Use a more recent date for pinning R packages, which include `bookdown >= 0.38`

Closes: #296