### PR TITLE
feat: update `GENERAL` and `PA2024CH` build configs to point to latest `2023Q4` data

### DIFF
--- a/build/config/rmi_pacta_2023q4_general.json
+++ b/build/config/rmi_pacta_2023q4_general.json
@@ -1,5 +1,5 @@
 {
-  "data_share_path": "2023Q4_20240301T105304Z",
+  "data_share_path": "2023Q4_20240424T120055Z",
   "index_share_path": "2023Q4_20240301T145404Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "GENERAL",

--- a/build/config/rmi_pacta_2023q4_general.json
+++ b/build/config/rmi_pacta_2023q4_general.json
@@ -1,6 +1,6 @@
 {
   "data_share_path": "2023Q4_20240424T120055Z",
-  "index_share_path": "2023Q4_20240301T145404Z",
+  "index_share_path": "2023Q4_20240425T162814Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "GENERAL",
   "templates_ref": "",

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -1,5 +1,5 @@
 {
-  "data_share_path": "2023Q4_20240301T105304Z",
+  "data_share_path": "2023Q4_20240424T120055Z",
   "index_share_path": "2023Q4_20240301T145404Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "PA2024CH",

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -1,6 +1,6 @@
 {
   "data_share_path": "2023Q4_20240424T120055Z",
-  "index_share_path": "2023Q4_20240301T145404Z",
+  "index_share_path": "2023Q4_20240425T162814Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "PA2024CH",
   "templates_ref": "",


### PR DESCRIPTION
Updates applied for `GENERAL` and `PA2024CH` pointing to `2023Q4` data. 

Azure directory: `2023Q4_20240424T120055Z`

Built from: https://github.com/RMI-PACTA/workflow.data.preparation/commit/5a96cc36b9d343b66bef2d518c6fb340eb686979