### PR TITLE
Include index prep

### DIFF
--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -24,11 +24,12 @@ jobs:
           github.event_name == 'schedule' && 'nightly' ||
           github.event_name == 'push' && github.ref_name ||
           github.event_name == 'workflow_dispatch' && github.ref_name ||
-          github.sha 
+          github.sha
         }}
 
   build_private_docker_image:
     name: "Build private docker image"
+    needs: build_docker_image
     strategy:
       # if one build or test fails, permit the others to run
       fail-fast: false

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -80,10 +80,6 @@ jobs:
           echo "PACTA_DATA_SHARE_PATH=$PACTA_DATA_SHARE_PATH"
           echo "PACTA_DATA_SHARE_PATH=$PACTA_DATA_SHARE_PATH" >> "$GITHUB_ENV"
 
-          INDEX_SHARE_PATH="$(jq -rc '.index_share_path' $config_file)"
-          echo "INDEX_SHARE_PATH=$INDEX_SHARE_PATH"
-          echo "INDEX_SHARE_PATH=$INDEX_SHARE_PATH" >> "$GITHUB_ENV"
-
           PACTA_DATA_QUARTER="$(jq -rc '.pacta_data_quarter' $config_file)"
           echo "PACTA_DATA_QUARTER=$PACTA_DATA_QUARTER"
           echo "PACTA_DATA_QUARTER=$PACTA_DATA_QUARTER" >> "$GITHUB_ENV"
@@ -103,6 +99,21 @@ jobs:
           path: templates.transition.monitor
           token: ${{ secrets.REPO_PAT }}
           ref: ${{ env.TEMPLATES_REF }}
+
+      - name: run Index Preparation
+        uses: RMI-PACTA/workflow.prepare.pacta.indices/.github/workflows/run-index-preparation.yml@main
+        id: index-prep
+        with:
+          image-tag: |
+            ${{
+              github.event_name == 'pull_request' && format('{0}{1}','pr', github.event.pull_request.number) ||
+              github.event_name == 'schedule' && 'main' ||
+              github.event_name == 'push' && github.ref_name ||
+              github.event_name == 'workflow_dispatch' && github.ref_name ||
+              github.sha
+            }}
+          data-share-path: ${{ ENV.PACTA_DATA_SHARE_PATH }}
+          config_active: ${{ ENV.PACTA_DATA_QUARTER }}
 
       # https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended
       - name: Azure Login
@@ -127,7 +138,7 @@ jobs:
             # download indices
             index_share_url="https://pactadatadev.file.core.windows.net/workflow-prepare-pacta-indices-outputs"
             az storage copy \
-              --source "$index_share_url"/"${{ env.INDEX_SHARE_PATH }}" \
+              --source "$index_share_url"/"${{ steps.index.prep.outputs.timestamp-dir }}" \
               --destination "index-data" \
               --recursive \
               --exclude-pattern "*.sqlite"

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -97,7 +97,7 @@ jobs:
     name: run Index Preparation
     needs: read-config
     secrets: inherit
-    uses: RMI-PACTA/workflow.prepare.pacta.indices/.github/workflows/run-index-preparation.yml@main
+    uses: RMI-PACTA/workflow.prepare.pacta.indices/.github/workflows/run-index-preparation.yml@gh-actions-updates
     with:
       image-tag: |
         ${{

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -97,7 +97,7 @@ jobs:
     name: Run Index Preparation
     needs: read-config
     secrets: inherit
-    uses: RMI-PACTA/workflow.prepare.pacta.indices/.github/workflows/run-index-preparation.yml@suppress-indices
+    uses: RMI-PACTA/workflow.prepare.pacta.indices/.github/workflows/run-index-preparation.yml@main
     with:
       image-tag: |
         ${{

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -148,7 +148,7 @@ jobs:
         uses: azure/CLI@v2
         env:
           pacta_data_share_path: ${{ needs.read-config.outputs.pacta-data-share-path }}
-          index_share_path: ${{ steps.index-prep.outputs.timestamp-dir }}
+          index_share_path: ${{ needs.prepare-indices.outputs.timestamp-dir }}
           pacta_data_quarter: ${{ needs.read-config.outputs.pacta-data-quarter }}
         with:
           # azcliversion: 2.30.0

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -155,7 +155,7 @@ jobs:
           inlineScript: |
             pacta_data_share_url="https://pactadatadev.file.core.windows.net/workflow-data-preparation-outputs"
             az storage copy \
-              --source "$pacta_data_share_url/$pacta_data_afs_path" \
+              --source "$pacta_data_share_url/$pacta_data_share_path" \
               --destination "pacta-data" \
               --recursive \
               --exclude-pattern "*.sqlite"

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -51,7 +51,7 @@ jobs:
       pacta-data-quarter: ${{ steps.prepare.outputs.pacta-data-quarter }}
       pacta-data-share-path: ${{ steps.prepare.outputs.pacta-data-share-path }}
       registry-image: ${{ steps.prepare.outputs.registry-image }}
-      tempates-ref: ${{ steps.prepare.outputs.tempates-ref }}
+      templates-ref: ${{ steps.prepare.outputs.templates-ref }}
       test-matrix: ${{ steps.prepare.outputs.test-matrix }}
     steps:
 

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -155,14 +155,14 @@ jobs:
           inlineScript: |
             pacta_data_share_url="https://pactadatadev.file.core.windows.net/workflow-data-preparation-outputs"
             az storage copy \
-              --source "$pacta_data_share_url"/"$pacta_data_afs_path" \
+              --source "$pacta_data_share_url/$pacta_data_afs_path" \
               --destination "pacta-data" \
               --recursive \
               --exclude-pattern "*.sqlite"
             # download indices
             index_share_url="https://pactadatadev.file.core.windows.net/workflow-prepare-pacta-indices-outputs"
             az storage copy \
-              --source "$index_share_url"/"$index_share_path" \
+              --source "$index_share_url/$index_share_path" \
               --destination "index-data" \
               --recursive \
               --exclude-pattern "*.sqlite"

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -106,8 +106,8 @@ jobs:
           github.event_name == 'workflow_dispatch' && github.ref_name ||
           github.sha
           }}
-      data-share-path: ${{ jobs.read-config.outputs.pacta-data-share-path }}
-      config_active: ${{ jobs.read-config.outputs.pacta-data-quarter }}
+      data-share-path: ${{ needs.read-config.outputs.pacta-data-share-path }}
+      config_active: ${{ needs.read-config.outputs.pacta-data-quarter }}
 
 
   docker-build:

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -97,7 +97,7 @@ jobs:
     name: Run Index Preparation
     needs: read-config
     secrets: inherit
-    uses: RMI-PACTA/workflow.prepare.pacta.indices/.github/workflows/run-index-preparation.yml@gh-actions-updates
+    uses: RMI-PACTA/workflow.prepare.pacta.indices/.github/workflows/run-index-preparation.yml@suppress-indices
     with:
       image-tag: |
         ${{

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -257,7 +257,7 @@ jobs:
       # if one test fails, permit the others to run
       fail-fast: false
       # build images in parallel
-      matrix: ${{ fromJson(needs.docker-build.outputs.test-matrix) }}
+      matrix: ${{ fromJson(needs.read-config.outputs.test-matrix) }}
     needs:
       - docker-build
     permissions:

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -262,6 +262,7 @@ jobs:
       # build images in parallel
       matrix: ${{ fromJson(needs.read-config.outputs.test-matrix) }}
     needs:
+      - read-config
       - docker-build
     permissions:
       contents: read

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -167,7 +167,7 @@ jobs:
               --recursive \
               --exclude-pattern "*.sqlite"
             # move data
-            mv "$pacta-data-share-path" "pacta-data/$pacta_data_quarter"
+            mv "pacta-data/$pacta_data_share_path" "pacta-data/$pacta_data_quarter"
             mv "index-data/$index_share_path"/* "pacta-data/$pacta_data_quarter"
             ls pacta-data/$pacta_data_quarter
 

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -94,7 +94,7 @@ jobs:
           echo "test-matrix=$TEST_MATRIX" >> "$GITHUB_OUTPUT"
 
   prepare-indices:
-    name: run Index Preparation
+    name: Run Index Preparation
     needs: read-config
     secrets: inherit
     uses: RMI-PACTA/workflow.prepare.pacta.indices/.github/workflows/run-index-preparation.yml@gh-actions-updates

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -120,7 +120,6 @@ jobs:
     timeout-minutes: 45
     outputs:
       full-image-name: ${{ steps.export-outputs.outputs.full-image-name }}
-      test-matrix: ${{ steps.prepare.outputs.test-matrix }}
 
     steps:
       - name: Checkout workflow.transition.monitor
@@ -147,26 +146,30 @@ jobs:
       # https://github.com/marketplace/actions/azure-cli-action#workflow-to-execute-an-azure-cli-script-of-a-specific-cli-version
       - name: Download pacta-data
         uses: azure/CLI@v2
+        env:
+          pacta_data_share_path: ${{ needs.read-config.outputs.pacta-data-share-path }}
+          index_share_path: ${{ steps.index-prep.outputs.timestamp-dir }}
+          pacta_data_quarter: ${{ needs.read-config.outputs.pacta-data-quarter }}
         with:
           # azcliversion: 2.30.0
           inlineScript: |
             pacta_data_share_url="https://pactadatadev.file.core.windows.net/workflow-data-preparation-outputs"
             az storage copy \
-              --source "$pacta_data_share_url"/"${{ needs.read-config.outputs.pacta-data-share-path }}" \
+              --source "$pacta_data_share_url"/"$pacta_data_afs_path" \
               --destination "pacta-data" \
               --recursive \
               --exclude-pattern "*.sqlite"
             # download indices
             index_share_url="https://pactadatadev.file.core.windows.net/workflow-prepare-pacta-indices-outputs"
             az storage copy \
-              --source "$index_share_url"/"${{ steps.index.prep.outputs.timestamp-dir }}" \
+              --source "$index_share_url"/"$index_share_path" \
               --destination "index-data" \
               --recursive \
               --exclude-pattern "*.sqlite"
             # move data
-            mv "pacta-data/${{ needs.read-config.outputs.pacta-data-share-path }}" "pacta-data/${{ needs.read-config.outputs.pacta-data-quarter }}"
-            mv "index-data/${{ needs.prepare-indices.outputs.timestamp-dir }}"/* "pacta-data/${{ needs.read-config.outputs.pacta-data-quarter }}"
-            ls pacta-data/${{ needs.read-config.outputs.pacta-data-quarter }}
+            mv "$pacta-data-share-path" "pacta-data/$pacta_data_quarter"
+            mv "index-data/$index_share_path"/* "pacta-data/$pacta_data_quarter"
+            ls pacta-data/$pacta_data_quarter
 
       - name: Identify LABELs in dockerfile
         id: custom-labels

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -96,6 +96,7 @@ jobs:
   prepare-indices:
     name: run Index Preparation
     needs: read-config
+    secrets: inherit
     uses: RMI-PACTA/workflow.prepare.pacta.indices/.github/workflows/run-index-preparation.yml@main
     with:
       image-tag: |

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -42,8 +42,77 @@ on:
         value: ${{ jobs.test.outputs.report-url }}
 
 jobs:
+  read-config:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      now: ${{ steps.prepare.outputs.now }}
+      pacta-data-quarter: ${{ steps.prepare.outputs.pacta-data-quarter }}
+      pacta-data-share-path: ${{ steps.prepare.outputs.pacta-data-share-path }}
+      registry-image: ${{ steps.prepare.outputs.registry-image }}
+      tempates-ref: ${{ steps.prepare.outputs.tempates-ref }}
+      test-matrix: ${{ steps.prepare.outputs.test-matrix }}
+    steps:
+
+      - name: Checkout workflow.transition.monitor
+        uses: actions/checkout@v4
+        with:
+          path: workflow.transition.monitor
+
+      - name: Prepare environment
+        id: prepare
+        run: |
+          NOW="$(date -u +'%Y%m%dT%H%M%SZ')"
+          echo "now=$NOW" >> $GITHUB_OUTPUT
+          echo "$NOW"
+
+          registry_image=$(
+            echo "${{ inputs.registry }}/${{ inputs.image-name }}" | \
+            tr '[:upper:]' '[:lower:]' \
+          )
+          REGISTRY_IMAGE=${registry_image}
+          echo "registry-image=$REGISTRY_IMAGE"
+          echo "registry-image=$REGISTRY_IMAGE" >> $GITHUB_OUTPUT
+
+          config_file="workflow.transition.monitor/build/config/${{ inputs.image-name }}.json"
+
+          PACTA_DATA_SHARE_PATH="$(jq -rc '.data_share_path' $config_file)"
+          echo "pacta-data-share-path=$PACTA_DATA_SHARE_PATH"
+          echo "pacta-data-share-path=$PACTA_DATA_SHARE_PATH" >> "$GITHUB_OUTPUT"
+
+          PACTA_DATA_QUARTER="$(jq -rc '.pacta_data_quarter' $config_file)"
+          echo "pacta-data-quarter=$PACTA_DATA_QUARTER"
+          echo "pacta-data-quarter=$PACTA_DATA_QUARTER" >> "$GITHUB_OUTPUT"
+
+          TEMPLATES_REF="$(jq -rc '.templates_ref' $config_file)"
+          echo "templates-ref=$TEMPLATES_REF"
+          echo "templates-ref=$TEMPLATES_REF" >> "$GITHUB_OUTPUT"
+
+          TEST_MATRIX="$(jq -c '.test_matrix' $config_file)"
+          echo "test-matrix=$TEST_MATRIX"
+          echo "test-matrix=$TEST_MATRIX" >> "$GITHUB_OUTPUT"
+
+  prepare-indices:
+    name: run Index Preparation
+    needs: read-config
+    uses: RMI-PACTA/workflow.prepare.pacta.indices/.github/workflows/run-index-preparation.yml@main
+    with:
+      image-tag: |
+        ${{
+          github.event_name == 'pull_request' && format('{0}{1}','pr', github.event.pull_request.number) ||
+          github.event_name == 'schedule' && 'main' ||
+          github.event_name == 'push' && github.ref_name ||
+          github.event_name == 'workflow_dispatch' && github.ref_name ||
+          github.sha
+          }}
+      data-share-path: ${{ jobs.read-config.outputs.pacta-data-share-path }}
+      config_active: ${{ jobs.read-config.outputs.pacta-data-quarter }}
+
+
   docker-build:
     runs-on: ubuntu-latest
+    needs: [read-config, prepare-indices]
     permissions:
       contents: read
       id-token: write
@@ -59,61 +128,13 @@ jobs:
         with:
           path: workflow.transition.monitor
 
-      - name: Prepare environment
-        id: prepare
-        run: |
-          NOW="$(date -u +'%Y%m%dT%H%M%SZ')"
-          echo "NOW=$NOW" >> $GITHUB_ENV
-          echo "$NOW"
-
-          registry_image=$(
-            echo "${{ inputs.registry }}/${{ inputs.image-name }}" | \
-            tr '[:upper:]' '[:lower:]' \
-          )
-          REGISTRY_IMAGE=${registry_image}
-          echo "REGISTRY_IMAGE=$REGISTRY_IMAGE"
-          echo "REGISTRY_IMAGE=$REGISTRY_IMAGE" >> $GITHUB_ENV
-
-          config_file="workflow.transition.monitor/build/config/${{ inputs.image-name }}.json"
-
-          PACTA_DATA_SHARE_PATH="$(jq -rc '.data_share_path' $config_file)"
-          echo "PACTA_DATA_SHARE_PATH=$PACTA_DATA_SHARE_PATH"
-          echo "PACTA_DATA_SHARE_PATH=$PACTA_DATA_SHARE_PATH" >> "$GITHUB_ENV"
-
-          PACTA_DATA_QUARTER="$(jq -rc '.pacta_data_quarter' $config_file)"
-          echo "PACTA_DATA_QUARTER=$PACTA_DATA_QUARTER"
-          echo "PACTA_DATA_QUARTER=$PACTA_DATA_QUARTER" >> "$GITHUB_ENV"
-
-          TEMPLATES_REF="$(jq -rc '.templates_ref' $config_file)"
-          echo "TEMPLATES_REF=$TEMPLATES_REF"
-          echo "TEMPLATES_REF=$TEMPLATES_REF" >> "$GITHUB_ENV"
-
-          TEST_MATRIX="$(jq -c '.test_matrix' $config_file)"
-          echo "test-matrix=$TEST_MATRIX"
-          echo "test-matrix=$TEST_MATRIX" >> "$GITHUB_OUTPUT"
-
       - name: Checkout templates.transition.monitor
         uses: actions/checkout@v4
         with:
           repository: RMI-PACTA/templates.transition.monitor
           path: templates.transition.monitor
           token: ${{ secrets.REPO_PAT }}
-          ref: ${{ env.TEMPLATES_REF }}
-
-      - name: run Index Preparation
-        uses: RMI-PACTA/workflow.prepare.pacta.indices/.github/workflows/run-index-preparation.yml@main
-        id: index-prep
-        with:
-          image-tag: |
-            ${{
-              github.event_name == 'pull_request' && format('{0}{1}','pr', github.event.pull_request.number) ||
-              github.event_name == 'schedule' && 'main' ||
-              github.event_name == 'push' && github.ref_name ||
-              github.event_name == 'workflow_dispatch' && github.ref_name ||
-              github.sha
-            }}
-          data-share-path: ${{ ENV.PACTA_DATA_SHARE_PATH }}
-          config_active: ${{ ENV.PACTA_DATA_QUARTER }}
+          ref: ${{ needs.read-config.outputs.templates-ref }}
 
       # https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended
       - name: Azure Login
@@ -131,7 +152,7 @@ jobs:
           inlineScript: |
             pacta_data_share_url="https://pactadatadev.file.core.windows.net/workflow-data-preparation-outputs"
             az storage copy \
-              --source "$pacta_data_share_url"/"${{ env.PACTA_DATA_SHARE_PATH }}" \
+              --source "$pacta_data_share_url"/"${{ needs.read-config.outputs.pacta-data-share-path }}" \
               --destination "pacta-data" \
               --recursive \
               --exclude-pattern "*.sqlite"
@@ -143,9 +164,9 @@ jobs:
               --recursive \
               --exclude-pattern "*.sqlite"
             # move data
-            mv "pacta-data/${{ env.PACTA_DATA_SHARE_PATH }}" "pacta-data/${{ env.PACTA_DATA_QUARTER }}"
-            mv "index-data/${{ env.INDEX_SHARE_PATH }}"/* "pacta-data/${{ env.PACTA_DATA_QUARTER }}"
-            ls pacta-data/${{ env.PACTA_DATA_QUARTER }}
+            mv "pacta-data/${{ needs.read-config.outputs.pacta-data-share-path }}" "pacta-data/${{ needs.read-config.outputs.pacta-data-quarter }}"
+            mv "index-data/${{ needs.prepare-indices.outputs.timestamp-dir }}"/* "pacta-data/${{ needs.read-config.outputs.pacta-data-quarter }}"
+            ls pacta-data/${{ needs.read-config.outputs.pacta-data-quarter }}
 
       - name: Identify LABELs in dockerfile
         id: custom-labels
@@ -164,7 +185,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: ${{ needs.read-config.outputs.registry-image }}
           annotations:
             ${{ env.DOCKERFILE_LABELS }}
           labels:
@@ -177,7 +198,7 @@ jobs:
             type=ref,event=tag
             type=ref,event=pr
             ${{ inputs.additional-image-tags }}
-            ${{ env.NOW }},priority=1100
+            ${{ needs.read-config.outputs.now }},priority=1100
 
       # set up our build environment
       - name: Set up QEMU

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -106,7 +106,7 @@ jobs:
           github.event_name == 'push' && github.ref_name ||
           github.event_name == 'workflow_dispatch' && github.ref_name ||
           github.sha
-          }}
+        }}
       data-share-path: ${{ needs.read-config.outputs.pacta-data-share-path }}
       config_active: ${{ needs.read-config.outputs.pacta-data-quarter }}
 

--- a/build/config/rmi_pacta_2022q4_general.json
+++ b/build/config/rmi_pacta_2022q4_general.json
@@ -1,6 +1,5 @@
 {
   "data_share_path": "2022Q4_20240218T194337Z",
-  "index_share_path": "2022Q4_20240304T205931Z",
   "pacta_data_quarter": "2022Q4",
   "project_code": "GENERAL",
   "templates_ref": "",

--- a/build/config/rmi_pacta_2023q4_general.json
+++ b/build/config/rmi_pacta_2023q4_general.json
@@ -1,6 +1,5 @@
 {
   "data_share_path": "2023Q4_20240424T120055Z",
-  "index_share_path": "2023Q4_20240425T162814Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "GENERAL",
   "templates_ref": "",

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -1,6 +1,5 @@
 {
   "data_share_path": "2023Q4_20240424T120055Z",
-  "index_share_path": "2023Q4_20240425T162814Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "PA2024CH",
   "templates_ref": "",


### PR DESCRIPTION
Add index preparation to steps of private docker image build.

Keeps pacta code and data in sync with what is included between index prep and CTM image

Depends on https://github.com/RMI-PACTA/workflow.prepare.pacta.indices/pull/97