### PR TITLE
adapt to new function signatures in `pacta.portfolio.allocate`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     jsonlite,
     knitr,
     pacta.executive.summary, 
-    pacta.portfolio.allocate, 
+    pacta.portfolio.allocate (>= 0.0.2.9001),
     pacta.portfolio.audit, 
     pacta.portfolio.import, 
     pacta.portfolio.report, 
@@ -48,7 +48,7 @@ Imports:
     shiny
 Remotes: 
     RMI-PACTA/pacta.executive.summary, 
-    RMI-PACTA/pacta.portfolio.allocate, 
+    RMI-PACTA/pacta.portfolio.allocate@fix/48-remove-globalenv,
     RMI-PACTA/pacta.portfolio.audit, 
     RMI-PACTA/pacta.portfolio.import, 
     RMI-PACTA/pacta.portfolio.report, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     jsonlite,
     knitr,
     pacta.executive.summary, 
-    pacta.portfolio.allocate (>= 0.0.2.9001),
+    pacta.portfolio.allocate,
     pacta.portfolio.audit, 
     pacta.portfolio.import, 
     pacta.portfolio.report, 
@@ -48,7 +48,7 @@ Imports:
     shiny
 Remotes: 
     RMI-PACTA/pacta.executive.summary, 
-    RMI-PACTA/pacta.portfolio.allocate@fix/48-remove-globalenv,
+    RMI-PACTA/pacta.portfolio.allocate,
     RMI-PACTA/pacta.portfolio.audit, 
     RMI-PACTA/pacta.portfolio.import, 
     RMI-PACTA/pacta.portfolio.report, 

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -106,7 +106,11 @@ if (inherits(port_raw_all_eq, "data.frame") && nrow(port_raw_all_eq) > 0) {
 
   if (has_map) {
     abcd_raw_eq <- get_abcd_raw("Equity")
-    map_eq <- merge_in_geography(company_all_eq, abcd_raw_eq)
+    map_eq <- merge_in_geography(
+      portfolio = company_all_eq,
+      ald_raw = abcd_raw_eq,
+      sector_list = sector_list
+    )
     rm(abcd_raw_eq)
 
     map_eq <- aggregate_map_data(map_eq)
@@ -189,7 +193,11 @@ if (inherits(port_raw_all_cb, "data.frame") && nrow(port_raw_all_cb) > 0) {
   if (has_map) {
     if (data_check(company_all_cb)) {
       abcd_raw_cb <- get_abcd_raw("Bonds")
-      map_cb <- merge_in_geography(company_all_cb, abcd_raw_cb)
+      map_cb <- merge_in_geography(
+        portfolio = company_all_cb,
+        ald_raw = abcd_raw_cb,
+        sector_list = sector_list
+      )
       rm(abcd_raw_cb)
 
       map_cb <- aggregate_map_data(map_cb)

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -107,7 +107,7 @@ if (inherits(port_raw_all_eq, "data.frame") && nrow(port_raw_all_eq) > 0) {
   if (has_map) {
     abcd_raw_eq <- get_abcd_raw(
       portfolio_type = "Equity",
-      data_path = analysis_inputs_path,
+      analysis_inputs_path = analysis_inputs_path,
       start_year = start_year,
       time_horizon = time_horizon,
       sector_list = sector_list
@@ -200,7 +200,7 @@ if (inherits(port_raw_all_cb, "data.frame") && nrow(port_raw_all_cb) > 0) {
     if (data_check(company_all_cb)) {
       abcd_raw_cb <- get_abcd_raw(
         portfolio_type = "Bonds",
-        data_path = analysis_inputs_path,
+        analysis_inputs_path = analysis_inputs_path,
         start_year = start_year,
         time_horizon = time_horizon,
         sector_list = sector_list

--- a/web_tool_script_2.R
+++ b/web_tool_script_2.R
@@ -105,7 +105,13 @@ if (inherits(port_raw_all_eq, "data.frame") && nrow(port_raw_all_eq) > 0) {
   port_all_eq <- bind_rows(port_pw_eq, port_own_eq)
 
   if (has_map) {
-    abcd_raw_eq <- get_abcd_raw("Equity")
+    abcd_raw_eq <- get_abcd_raw(
+      portfolio_type = "Equity",
+      data_path = analysis_inputs_path,
+      start_year = start_year,
+      time_horizon = time_horizon,
+      sector_list = sector_list
+    )
     map_eq <- merge_in_geography(
       portfolio = company_all_eq,
       ald_raw = abcd_raw_eq,
@@ -192,7 +198,13 @@ if (inherits(port_raw_all_cb, "data.frame") && nrow(port_raw_all_cb) > 0) {
 
   if (has_map) {
     if (data_check(company_all_cb)) {
-      abcd_raw_cb <- get_abcd_raw("Bonds")
+      abcd_raw_cb <- get_abcd_raw(
+        portfolio_type = "Bonds",
+        data_path = analysis_inputs_path,
+        start_year = start_year,
+        time_horizon = time_horizon,
+        sector_list = sector_list
+      )
       map_cb <- merge_in_geography(
         portfolio = company_all_cb,
         ald_raw = abcd_raw_cb,


### PR DESCRIPTION
Adapting to https://github.com/RMI-PACTA/pacta.portfolio.allocate/pull/49/

Depends on and incorporates changes needed for https://github.com/RMI-PACTA/pacta.portfolio.allocate/pull/49

CLoses #317 