### PR TITLE
Reduce Testing Matrix

### DIFF
--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -18,6 +18,26 @@
     ],
     "include": [
       {
+        "peer_group": "bank",
+        "user_id": 74,
+        "language": "DE"
+      },
+      {
+        "peer_group": "other",
+        "user_id": 74,
+        "language": "DE"
+      },
+      {
+        "peer_group": "bank",
+        "user_id": 74,
+        "language": "FR"
+      },
+      {
+        "peer_group": "other",
+        "user_id": 74,
+        "language": "FR"
+      },
+      {
         "peer_group": "assetmanager",
         "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240515T164322Z/assetmanager"
       },
@@ -32,26 +52,6 @@
       {
         "peer_group": "pensionfund",
         "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240515T164322Z/pensionfund"
-      },
-      {
-        "peer_group": "bank",
-        "user_id": 74,
-        "language": "DE"
-      },
-      {
-        "peer_group": "other",
-        "user_id": 74,
-        "language": "DE"
-      },
-      {
-        "peer_group": "bank",
-        "user_id": 74,
-        "language": "FR"
-      },
-      {
-        "peer_group": "other",
-        "user_id": 74,
-        "language": "FR"
       }
     ]
   }

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -35,18 +35,22 @@
       },
       {
         "peer_group": "bank",
+        "user_id": 74,
         "language": "DE"
       },
       {
         "peer_group": "other",
+        "user_id": 74,
         "language": "DE"
       },
       {
         "peer_group": "bank",
+        "user_id": 74,
         "language": "FR"
       },
       {
         "peer_group": "other",
+        "user_id": 74,
         "language": "FR"
       }
     ]

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -18,24 +18,26 @@
     ],
     "include": [
       {
+        "user_id": 74,
+        "language": "DE",
         "peer_group": "bank",
-        "user_id": 74,
-        "language": "DE"
+        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240515T164322Z/bank"
       },
       {
-        "peer_group": "other",
         "user_id": 74,
-        "language": "DE"
+        "language": "DE",
+        "peer_group": "other"
       },
       {
+        "user_id": 74,
+        "language": "FR",
         "peer_group": "bank",
-        "user_id": 74,
-        "language": "FR"
+        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240515T164322Z/bank"
       },
       {
-        "peer_group": "other",
         "user_id": 74,
-        "language": "FR"
+        "language": "FR",
+        "peer_group": "other"
       },
       {
         "peer_group": "assetmanager",

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -7,9 +7,7 @@
   "test_matrix": {
     "user_id": ["74"],
     "language": [
-      "EN",
-      "DE",
-      "FR"
+      "EN"
     ],
     "peer_group": [
       "assetmanager",
@@ -34,6 +32,22 @@
       {
         "peer_group": "pensionfund",
         "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240515T164322Z/pensionfund"
+      },
+      {
+        "peer_group": "bank",
+        "language": "DE"
+      },
+      {
+        "peer_group": "other",
+        "language": "DE"
+      },
+      {
+        "peer_group": "bank",
+        "language": "FR"
+      },
+      {
+        "peer_group": "other",
+        "language": "FR"
       }
     ]
   }


### PR DESCRIPTION
Only run DE and FR for `bank` and `other` peer groups (to confirm "other" doesn't get peer results).

Closes #318 (hopefully)