### PR TITLE
Add a parameter to executive summary calculations

### DIFF
--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -46,6 +46,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      net-zero-targets: ${{ steps.prepare.outputs.net-zero-targets }}
       now: ${{ steps.prepare.outputs.now }}
       pacta-data-quarter: ${{ steps.prepare.outputs.pacta-data-quarter }}
       pacta-data-share-path: ${{ steps.prepare.outputs.pacta-data-share-path }}
@@ -107,6 +108,11 @@ jobs:
           echo "peer-results=$PEER_RESULTS"
           echo "peer-results=$PEER_RESULTS" >> "$GITHUB_OUTPUT"
 
+          # includes handling for null/missing keys
+          NET_ZERO_TARGETS="$(jq -r '.net_zero_targets | select( . != null )' $config_file)"
+          echo "net-zero-targets=$NET_ZERO_TARGETS"
+          echo "net-zero-targets=$NET_ZERO_TARGETS" >> "$GITHUB_OUTPUT"
+
   prepare-indices:
     name: Run Index Preparation
     needs: read-config
@@ -165,6 +171,7 @@ jobs:
           pacta_data_quarter: ${{ needs.read-config.outputs.pacta-data-quarter }}
           pacta_data_share_path: ${{ needs.read-config.outputs.pacta-data-share-path }}
           peer_results: ${{ needs.read-config.outputs.peer-results }}
+          net_zero_targets: ${{ needs.read-config.outputs.net-zero-targets }}
         with:
           # azcliversion: 2.30.0
           inlineScript: |
@@ -186,6 +193,16 @@ jobs:
             if [ -n "$peer_results" ]; then
               az storage copy \
                 --source "$peer_results/*" \
+                --destination "peer_results" \
+                --recursive
+            else
+              echo "No Peer Results defined in config"
+            fi
+
+            # Download net zero targets if necessary
+            if [ -n "$net_zero_targets" ]; then
+              az storage copy \
+                --source "$net_zero_targets" \
                 --destination "peer_results" \
                 --recursive
             else

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     rmarkdown, 
     shiny
 Remotes: 
-    RMI-PACTA/pacta.executive.summary, 
+    RMI-PACTA/pacta.executive.summary@update-sbti-section-scorecard, 
     RMI-PACTA/pacta.portfolio.allocate,
     RMI-PACTA/pacta.portfolio.audit, 
     RMI-PACTA/pacta.portfolio.import, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     rmarkdown, 
     shiny
 Remotes: 
-    RMI-PACTA/pacta.executive.summary@update-sbti-section-scorecard, 
+    RMI-PACTA/pacta.executive.summary, 
     RMI-PACTA/pacta.portfolio.allocate,
     RMI-PACTA/pacta.portfolio.audit, 
     RMI-PACTA/pacta.portfolio.import, 

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -4,6 +4,7 @@
   "project_code": "PA2024CH",
   "templates_ref": "",
   "peer_results": "https://pactadatadev.blob.core.windows.net/testing-files/peer-results/PA2024CH_peer-results-test",
+  "net_zero_targets": "https://pactadatadev.blob.core.windows.net/project-files/pa2024ch/fin_data_net_zero_targets.csv",
   "test_matrix": {
     "user_id": ["74"],
     "language": [
@@ -21,7 +22,7 @@
         "user_id": 74,
         "language": "DE",
         "peer_group": "bank",
-        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240617-no-index/bank"
+        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240702/bank"
       },
       {
         "user_id": 74,
@@ -32,7 +33,7 @@
         "user_id": 74,
         "language": "FR",
         "peer_group": "bank",
-        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240617-no-index/bank"
+        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240702/bank"
       },
       {
         "user_id": 74,
@@ -41,19 +42,19 @@
       },
       {
         "peer_group": "assetmanager",
-        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240617-no-index/assetmanager"
+        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240702/assetmanager"
       },
       {
         "peer_group": "bank",
-        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240617-no-index/bank"
+        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240702/bank"
       },
       {
         "peer_group": "insurance",
-        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240617-no-index/insurance"
+        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240702/insurance"
       },
       {
         "peer_group": "pensionfund",
-        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240617-no-index/pensionfund"
+        "user_results": "https://pactadatadev.blob.core.windows.net/testing-files/user-results/PA2024CH_peer-test/20240702/pensionfund"
       }
     ]
   }

--- a/web_tool_script_3.R
+++ b/web_tool_script_3.R
@@ -377,6 +377,7 @@ create_interactive_report(
 
 survey_dir <- fs::path_abs(file.path(user_results_path, project_code, "survey"))
 score_card_dir <- fs::path_abs(file.path(user_results_path, project_code, "score_card"))
+analysis_inputs_dir <- fs::path_abs(file.path(analysis_inputs_path))
 output_dir <- file.path(outputs_path, portfolio_name_ref_all)
 es_dir <- file.path(output_dir, "executive_summary")
 if (!dir.exists(es_dir)) {
@@ -433,6 +434,7 @@ if (dir.exists(exec_summary_template_path) && (peer_group %in% c("assetmanager",
     exec_summary_dir = exec_summary_template_path,
     survey_dir = survey_dir,
     score_card_dir = score_card_dir,
+    analysis_inputs_dir = analysis_inputs_dir,
     file_name = "template.Rmd",
     investor_name = investor_name,
     portfolio_name = portfolio_name,


### PR DESCRIPTION
With the new SBTi calculation we need to pass to executive summary the directory when pacta inputs are because that is where the file with SBTi data merged with FactSet data will live.

This depends on a PR in executive summary: https://github.com/RMI-PACTA/pacta.executive.summary/pull/346. This PR needs to be merged first for this one to work. Also, the `pacta-data` folder needs to contain `fin_data_net_zero_targets.csv` and has to use the most recent version of the testing `user_data` (https://github.com/RMI-PACTA/user_results/pull/24/files/f75b9955f640a74124003e524a6a5789d9b616b8..355ef24f21422238c88be9ad6ff571ef2d5e56db).