### PR TITLE
config: point `pa2024ch` to data prep with new weo 2023 scenarios

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     rmarkdown, 
     shiny
 Remotes: 
-    RMI-PACTA/pacta.executive.summary@jdhoffa-patch-1, 
+    RMI-PACTA/pacta.executive.summary, 
     RMI-PACTA/pacta.portfolio.allocate,
     RMI-PACTA/pacta.portfolio.audit, 
     RMI-PACTA/pacta.portfolio.import, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     rmarkdown, 
     shiny
 Remotes: 
-    RMI-PACTA/pacta.executive.summary, 
+    RMI-PACTA/pacta.executive.summary@jdhoffa-patch-1, 
     RMI-PACTA/pacta.portfolio.allocate,
     RMI-PACTA/pacta.portfolio.audit, 
     RMI-PACTA/pacta.portfolio.import, 

--- a/build/config/rmi_pacta_2023q4_general.json
+++ b/build/config/rmi_pacta_2023q4_general.json
@@ -1,5 +1,5 @@
 {
-  "data_share_path": "2023Q4_20240701T114132Z",
+  "data_share_path": "2023Q4_20240709T111731Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "GENERAL",
   "templates_ref": "",

--- a/build/config/rmi_pacta_2023q4_general.json
+++ b/build/config/rmi_pacta_2023q4_general.json
@@ -1,5 +1,5 @@
 {
-  "data_share_path": "2023Q4_20240424T120055Z",
+  "data_share_path": "2023Q4_20240701T114132Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "GENERAL",
   "templates_ref": "",

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -1,5 +1,5 @@
 {
-  "data_share_path": "2023Q4_20240424T120055Z",
+  "data_share_path": "2023Q4_20240701T114132Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "PA2024CH",
   "templates_ref": "",

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -3,7 +3,7 @@
   "pacta_data_quarter": "2023Q4",
   "project_code": "PA2024CH",
   "templates_ref": "",
-  "peer_results": "https://pactadatadev.blob.core.windows.net/testing-files/peer-results/PA2024CH_peer-results-test",
+  "peer_results": "https://pactadatadev.blob.core.windows.net/project-files/pa2024ch/peer_files",
   "net_zero_targets": "https://pactadatadev.blob.core.windows.net/project-files/pa2024ch/fin_data_net_zero_targets.csv",
   "test_matrix": {
     "user_id": [

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -1,12 +1,14 @@
 {
-  "data_share_path": "2023Q4_20240701T114132Z",
+  "data_share_path": "2023Q4_20240709T111731Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "PA2024CH",
   "templates_ref": "",
   "peer_results": "https://pactadatadev.blob.core.windows.net/testing-files/peer-results/PA2024CH_peer-results-test",
   "net_zero_targets": "https://pactadatadev.blob.core.windows.net/project-files/pa2024ch/fin_data_net_zero_targets.csv",
   "test_matrix": {
-    "user_id": ["74"],
+    "user_id": [
+      "74"
+    ],
     "language": [
       "EN"
     ],


### PR DESCRIPTION
The newly created data directory now contains APS and STEPS scenarios for WEO 2023 for the aviation, cement and steel sectors. 

Importantly also, we had to update paths to the new (real) `peer` files, as those had to be re-run with those same latest scenarios. 

With these scenarios missing, the executive summary couldn't render correctly. 

Relates to:
RMI-PACTA/workflow.data.preparation/pull/238
RMI-PACTA/workflow.data.preparation/pull/237
RMI-PACTA/workflow.data.preparation/pull/236
RMI-PACTA/pacta.scenario.data.preparation/pull/61
RMI-PACTA/pacta.scenario.data.preparation/pull/63