### PR TITLE
config: bump `2023Q4` configuration to latest run of data preparation

### DIFF
--- a/build/config/rmi_pacta_2023q4_general.json
+++ b/build/config/rmi_pacta_2023q4_general.json
@@ -1,15 +1,11 @@
 {
-  "data_share_path": "2023Q4_20240709T111731Z",
+  "data_share_path": "2023Q4_20240718T150252Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "GENERAL",
   "templates_ref": "",
   "test_matrix": {
-    "language": [
-      "EN"
-    ],
-    "peer_group": [
-      "other"
-    ]
+    "language": ["EN"],
+    "peer_group": ["other"]
   },
   "resultsDestinationURL": "https://pactadatadev.blob.core.windows.net/ghactions-workflow-transition-monitor-results-full",
   "reportsDestinationURL": "https://pactadatadev.blob.core.windows.net/ghactions-workflow-transition-monitor-results-reports"

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -1,24 +1,14 @@
 {
-  "data_share_path": "2023Q4_20240709T111731Z",
+  "data_share_path": "2023Q4_20240718T150252Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "PA2024CH",
   "templates_ref": "",
   "peer_results": "https://pactadatadev.blob.core.windows.net/project-files/pa2024ch/peer_files",
   "net_zero_targets": "https://pactadatadev.blob.core.windows.net/project-files/pa2024ch/fin_data_net_zero_targets.csv",
   "test_matrix": {
-    "user_id": [
-      "74"
-    ],
-    "language": [
-      "EN"
-    ],
-    "peer_group": [
-      "assetmanager",
-      "bank",
-      "insurance",
-      "other",
-      "pensionfund"
-    ],
+    "user_id": ["74"],
+    "language": ["EN"],
+    "peer_group": ["assetmanager", "bank", "insurance", "other", "pensionfund"],
     "include": [
       {
         "user_id": 74,


### PR DESCRIPTION
The `financial_data` output is now filtered for cases where `shares_all_classes > 0`:
Relates to https://github.com/RMI-PACTA/pacta.data.preparation/pull/33

Leaving as a draft until I am able to re-run `peer_results` to confirm that CI/CD build are functional.