### PR TITLE
add archive export for inputs

### DIFF
--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -297,6 +297,27 @@ jobs:
           echo "full-image-name=$TAGGED_IMAGE"
           echo "full-image-name=$TAGGED_IMAGE" >> "$GITHUB_OUTPUT"
 
+      - name: Export inputs archive
+        uses: azure/CLI@v2
+        env:
+          full_image_name: ${{ steps.export-outputs.outputs.full-image-name }}
+        with:
+          inlineScript: |
+            tarfile="$(echo $full_image_name | sed 's:.*/::' |  tr ":" "-").tar.gz"
+            echo "$tarfile"
+            tar -cvz -f "$tarfile" pacta-data templates.transition.monitor
+
+            upload_container="https://pactadatadev.blob.core.windows.net/ghactions-workflow-transition-monitor-input-pacta-data"
+            destination_path="$upload_container/$tarfile"
+            echo "$destination_path"
+
+            az storage copy \
+            --source "$tarfile" \
+            --destination "$destination_path" \
+            --recursive
+
+            echo "Archive available at: $destination_path"
+
   test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Pack the `pacta-data` and `templates.transition.monitor` directories that were used to build the image, and upload archive to Azure Blob container.

Closes #348.