### PR TITLE
Move packing inputs archive to separate step

### DIFF
--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -303,13 +303,12 @@ jobs:
         id: prepare-inputs-archive
         env:
           full_image_name: ${{ steps.export-outputs.outputs.full-image-name }}
-        with:
-          inlineScript: |
-            tarfile="$(echo $full_image_name | sed 's:.*/::' |  tr ":" "-").tar.gz"
-            tar -cvz -f "$tarfile" pacta-data templates.transition.monitor
-            echo "$tarfile"
-            echo "input-tar=$tarfile"
-            echo "input-tar=$tarfile" >> "$GITHUB_OUTPUT"
+        run: |
+          tarfile="$(echo $full_image_name | sed 's:.*/::' |  tr ":" "-").tar.gz"
+          tar -cvz -f "$tarfile" pacta-data templates.transition.monitor
+          echo "$tarfile"
+          echo "input-tar=$tarfile"
+          echo "input-tar=$tarfile" >> "$GITHUB_OUTPUT"
 
 
       - name: Export inputs archive

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -299,16 +299,26 @@ jobs:
           echo "full-image-name=$TAGGED_IMAGE"
           echo "full-image-name=$TAGGED_IMAGE" >> "$GITHUB_OUTPUT"
 
-      - name: Export inputs archive
-        uses: azure/CLI@v2
+      - name: Prepare inputs archive
+        id: prepare-inputs-archive
         env:
           full_image_name: ${{ steps.export-outputs.outputs.full-image-name }}
         with:
           inlineScript: |
             tarfile="$(echo $full_image_name | sed 's:.*/::' |  tr ":" "-").tar.gz"
-            echo "$tarfile"
             tar -cvz -f "$tarfile" pacta-data templates.transition.monitor
+            echo "$tarfile"
+            echo "input-tar=$tarfile"
+            echo "input-tar=$tarfile" >> "$GITHUB_OUTPUT"
 
+
+      - name: Export inputs archive
+        uses: azure/CLI@v2
+        env:
+          full_image_name: ${{ steps.export-outputs.outputs.full-image-name }}
+          tarfile: ${{ steps.prepare-inputs-archive.outputs.input-tar }}
+        with:
+          inlineScript: |
             upload_container="https://pactadatadev.blob.core.windows.net/ghactions-workflow-transition-monitor-input-pacta-data"
             destination_path="$upload_container/$tarfile"
             echo "$destination_path"


### PR DESCRIPTION
Similar to https://github.com/RMI-PACTA/workflow.prepare.pacta.indices/pull/110

It seems that the `azure/cli` image removed a bunch of unix utils, including `tar`, so similar to liked PR, I'm breaking the step into two, one to run the unix command, and another for the `az` part of things. 

in this case, using `tar` to prepare the inputs archive, and then `az` in the second to move it to persistent storage.