### PR TITLE
Add build config for sectoral reports

### DIFF
--- a/.github/workflows/build-Docker-image-triggers.yml
+++ b/.github/workflows/build-Docker-image-triggers.yml
@@ -37,6 +37,7 @@ jobs:
       matrix:
         image-name:
           - rmi_pacta_2023q4_pa2024ch
+          - rmi_pacta_2023q4_pa2024ch_sectoral
           - rmi_pacta_2022q4_general
           - rmi_pacta_2023q4_general
     uses: ./.github/workflows/build-push-private.yml

--- a/build/config/rmi_pacta_2023q4_pa2024ch_sectoral.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch_sectoral.json
@@ -2,7 +2,7 @@
   "data_share_path": "2023Q4_20240718T150252Z",
   "pacta_data_quarter": "2023Q4",
   "project_code": "PA2024CH_sectoral",
-  "templates_ref": "add-sectoral-report",
+  "templates_ref": "",
   "test_matrix": {
     "language": ["EN", "DE", "FR"],
     "peer_group": ["other"]

--- a/build/config/rmi_pacta_2023q4_pa2024ch_sectoral.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch_sectoral.json
@@ -1,0 +1,12 @@
+{
+  "data_share_path": "2023Q4_20240718T150252Z",
+  "pacta_data_quarter": "2023Q4",
+  "project_code": "PA2024CH_sectoral",
+  "templates_ref": "add-sectoral-report",
+  "test_matrix": {
+    "language": ["EN", "DE", "FR"],
+    "peer_group": ["other"]
+  },
+  "resultsDestinationURL": "https://pactadatadev.blob.core.windows.net/ghactions-workflow-transition-monitor-results-full",
+  "reportsDestinationURL": "https://pactadatadev.blob.core.windows.net/ghactions-workflow-transition-monitor-results-reports"
+}

--- a/parameter_files/ProjectParameters_PA2024CH_sectoral.yml
+++ b/parameter_files/ProjectParameters_PA2024CH_sectoral.yml
@@ -4,7 +4,7 @@ default:
         data_location_ext: ../pacta-data/2023Q4/
 
     reporting:
-        project_report_name: PA2024CH
+        project_report_name: PA2024CH_sectoral
         display_currency: CHF
         currency_exchange_value: 1.190405
 

--- a/parameter_files/ProjectParameters_PA2024CH_sectoral.yml
+++ b/parameter_files/ProjectParameters_PA2024CH_sectoral.yml
@@ -1,0 +1,58 @@
+default:
+
+    paths:
+        data_location_ext: ../pacta-data/2023Q4/
+
+    reporting:
+        project_report_name: PA2024CH
+        display_currency: CHF
+        currency_exchange_value: 1.190405
+
+    parameters:
+        start_year: 2023
+        horizon_year: 5
+        select_scenario: WEO2023_NZE_2050
+        scenario_other: WEO2023_NZE_2050
+        portfolio_allocation_method: portfolio_weight
+        scenario_geography: Global
+
+    methodology:
+        has_map: TRUE
+        has_revenue: FALSE
+        has_credit: FALSE
+        inc_emissionfactors: TRUE
+
+    sectors:
+        tech_roadmap_sectors:
+            - Power
+            - Automotive
+            - Oil&Gas
+            - Coal
+        pacta_sectors_not_analysed:
+            - Steel
+            - Aviation
+            - Cement
+        green_techs:
+            - RenewablesCap
+            - HydroCap
+            - NuclearCap
+            - Hybrid
+            - Electric
+            - FuelCell
+            - Electric Arc Furnace
+
+    scenario_sources_list:
+        - GECO2023
+        - ISF2023
+        - WEO2023
+
+    scenario_geography_list:
+        - Global
+        - GlobalAggregate
+        - NonOECD
+        - OECD
+
+    equity_market_list:
+        - GlobalMarket
+        - DevelopedMarket
+        - EmergingMarket


### PR DESCRIPTION
Add testing configurations for Sectoral Reports for PA2024 CH 

Depends on https://github.com/RMI-PACTA/templates.transition.monitor/pull/51