### PR TITLE
Add testing files with extra JSON Array

### DIFF
--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -365,7 +365,7 @@ jobs:
           echo "TEST_DIR_PARENT=$TEST_DIR_PARENT"
           echo "test-dir-parent=$TEST_DIR_PARENT" >> "$GITHUB_OUTPUT"
 
-          TEST_DIR="$TEST_DIR_PARENT/$language/$peer_group/$run_attempt/$RANDOM"
+          TEST_DIR="$TEST_DIR_PARENT/$language/$peer_group/$run_attempt"
           mkdir -p "$TEST_DIR"
           chmod -R 777 "$TEST_DIR"
           echo "TEST_DIR=$TEST_DIR"

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -365,7 +365,7 @@ jobs:
           echo "TEST_DIR_PARENT=$TEST_DIR_PARENT"
           echo "test-dir-parent=$TEST_DIR_PARENT" >> "$GITHUB_OUTPUT"
 
-          TEST_DIR="$TEST_DIR_PARENT/$language/$peer_group/$run_attempt"
+          TEST_DIR="$TEST_DIR_PARENT/$language/$peer_group/$run_attempt/$RANDOM"
           mkdir -p "$TEST_DIR"
           chmod -R 777 "$TEST_DIR"
           echo "TEST_DIR=$TEST_DIR"

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -474,7 +474,7 @@ jobs:
         id: upload-results
         uses: RMI-PACTA/actions/actions/azure/blob-copy@main
         with:
-          source: ${{ steps.prepare-results-dir.outputs.test-dir-parent }}
+          source: ${{ steps.prepare-results-dir.outputs.test-dir }}
           destination: https://pactadatadev.blob.core.windows.net/ghactions-workflow-transition-monitor-results-full
           overwrite: false
 
@@ -482,7 +482,7 @@ jobs:
         id: upload-report
         uses: RMI-PACTA/actions/actions/azure/blob-copy@main
         with:
-          source: ${{ steps.prepare-results-dir.outputs.test-dir-parent }}/${{ matrix.language }}/${{ matrix.peer_group }}/${{ github.run_attempt }}/working_dir/50_Outputs
+          source: ${{ steps.prepare-results-dir.outputs.test-dir }}/working_dir/50_Outputs
           destination: https://pactadatadev.blob.core.windows.net/ghactions-workflow-transition-monitor-results-reports
           overwrite: false
 

--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -408,9 +408,13 @@ jobs:
         if: ${{ matrix.user_results }}
         env:
           USER_RESULTS_DIR: ${{ steps.prepare-results-dir.outputs.test-dir }}/user_dir
+          BLOB_SOURCE: ${{ matrix.user_results }}/${{ matrix.user_id }}
           USER_ID: ${{ matrix.user_id }}
         run: |
-          TEMP_USER_DIR="$USER_RESULTS_DIR/outputs/user_data/$USER_ID"
+          BLOB_STUB="$(echo $BLOB_SOURCE | sed -e 's/.*windows.net\/[^\/]*\///')"
+          echo "Blob stub: $BLOB_STUB"
+          TEMP_USER_DIR="$USER_RESULTS_DIR/$BLOB_STUB"
+          echo "Temp Dir user: $TEMP_USER_DIR"
           if [ -d $TEMP_USER_DIR ]; then
             mv \
               --verbose \

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Remotes:
     RMI-PACTA/pacta.portfolio.allocate,
     RMI-PACTA/pacta.portfolio.audit, 
     RMI-PACTA/pacta.portfolio.import, 
-    RMI-PACTA/pacta.portfolio.report, 
+    RMI-PACTA/pacta.portfolio.report@97-extra-re-array, 
     RMI-PACTA/pacta.portfolio.utils
 Depends: 
     R (>= 3.5.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Remotes:
     RMI-PACTA/pacta.portfolio.allocate,
     RMI-PACTA/pacta.portfolio.audit, 
     RMI-PACTA/pacta.portfolio.import, 
-    RMI-PACTA/pacta.portfolio.report@97-extra-re-array, 
+    RMI-PACTA/pacta.portfolio.report, 
     RMI-PACTA/pacta.portfolio.utils
 Depends: 
     R (>= 3.5.0)

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -10,7 +10,7 @@
     "language": ["EN", "DE", "FR"],
     "user_results": [
       "https://pactadatadev.blob.core.windows.net/pa2024ch/outputs/user_data",
-      "https://pactadatadev.blob.core.windows.net/pa2024ch/outputs/user_data_extra_array"
+      "https://pactadatadev.blob.core.windows.net/pa2024ch/outputs/extra_array/user_data"
     ],
     "exclude": [
       {

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -9,7 +9,6 @@
     "peer_group": ["bank", "assetmanager", "insurance", "pensionfund", "other"],
     "language": ["EN", "DE", "FR"],
     "user_results": [
-      "https://pactadatadev.blob.core.windows.net/pa2024ch/outputs/user_data",
       "https://pactadatadev.blob.core.windows.net/pa2024ch/outputs/extra_array/user_data"
     ],
     "exclude": [

--- a/build/config/rmi_pacta_2023q4_pa2024ch.json
+++ b/build/config/rmi_pacta_2023q4_pa2024ch.json
@@ -8,7 +8,10 @@
   "test_matrix": {
     "peer_group": ["bank", "assetmanager", "insurance", "pensionfund", "other"],
     "language": ["EN", "DE", "FR"],
-    "user_results": ["https://pactadatadev.blob.core.windows.net/pa2024ch/outputs/user_data"],
+    "user_results": [
+      "https://pactadatadev.blob.core.windows.net/pa2024ch/outputs/user_data",
+      "https://pactadatadev.blob.core.windows.net/pa2024ch/outputs/user_data_extra_array"
+    ],
     "exclude": [
       {
         "language": "DE",


### PR DESCRIPTION
In support of https://github.com/RMI-PACTA/pacta.portfolio.report/issues/97

Allows for testing user_results directories at non-standard blob locations.