### PR TITLE
revert #397 which does not appear to be necessary anymore

### DIFF
--- a/.github/workflows/build-push-private.yml
+++ b/.github/workflows/build-push-private.yml
@@ -162,7 +162,6 @@ jobs:
         with:
           # azcliversion: 2.30.0
           inlineScript: |
-            tdnf install -y azcopy;
             pacta_data_share_url="https://pactadatadev.file.core.windows.net/workflow-data-preparation-outputs"
             az storage copy \
               --source "$pacta_data_share_url/$pacta_data_share_path" \


### PR DESCRIPTION
- reverts #397 

This bug seems to have been fixed on Azure's side https://github.com/Azure/azure-cli/issues/30635#issuecomment-2651312166

Now there's a new unrelated CI error:
``` shell
Determining the default branch
  Retrieving the default branch name
  Bad credentials - https://docs.github.com/rest
  Waiting 16 seconds before trying again
  Retrieving the default branch name
  Bad credentials - https://docs.github.com/rest
  Waiting 18 seconds before trying again
  Retrieving the default branch name
  Error: Bad credentials - https://docs.github.com/rest
```